### PR TITLE
feat(graphics): Implement Phase 1 of Vulkan Backend for Basic Triangl…

### DIFF
--- a/examples/simple_vulkan_triangle/main.odin
+++ b/examples/simple_vulkan_triangle/main.odin
@@ -1,0 +1,260 @@
+package main
+
+import "core:fmt"
+import "core:log"
+import "core:mem"
+import "core:os"
+import "core:strings"
+
+import "odingame:core"
+import gfx "odingame:graphics" 
+// Renamed to avoid conflict with local 'graphics' if any, and for brevity
+import "odingame:math"
+
+
+Vertex :: struct {
+	pos: [2]f32, // x, y
+	col: [3]f32, // r, g, b
+}
+
+// Standard Counter-Clockwise (CCW) winding order for Vulkan's default frontFace.
+// Y points down in NDC, so -0.5 is top, 0.5 is bottom.
+triangle_vertices := [?]Vertex{
+    {{0.0, -0.5}, {1.0, 0.0, 0.0}},  // Top, Red
+    {{0.5, 0.5},  {0.0, 1.0, 0.0}},  // Bottom Right, Green
+    {{-0.5, 0.5}, {0.0, 0.0, 1.0}}, // Bottom Left, Blue
+}
+
+// Helper to read shader file
+read_shader_file :: proc(filepath: string, allocator := context.allocator) -> (string, bool) {
+	data, ok := os.read_entire_file(filepath, allocator)
+	if !ok {
+		log.errorf("Failed to read shader file: %s", filepath)
+		return "", false
+	}
+	// Ensure it's a valid Odin string (UTF-8, though GLSL is usually ASCII)
+	// For simplicity, directly convert. Proper validation might be needed.
+	return string(data), true
+}
+
+
+main :: proc() {
+	// Initialize logger
+	log.set_level(.Debug) // Set to .Info or .Warning for less verbose output
+	log.info("Starting Simple Vulkan Triangle Example...")
+
+	// Game Config
+	config := core.Game_Config{
+		window_title  = "Simple Vulkan Triangle",
+		window_width  = 800,
+		window_height = 600,
+		graphics_backend = .Vulkan, // Specify Vulkan backend
+	}
+
+	// Initialize Game
+	if !core.init_game(config) {
+		log.error("Failed to initialize game core.")
+		return
+	}
+	defer core.shutdown_game()
+
+	// Get device and window
+	gfx_device := core.get_device()
+	main_window := core.get_main_window()
+
+	if gfx_device == nil || main_window == nil {
+		log.error("Failed to get graphics device or main window from core.")
+		return
+	}
+	log.info("Game core initialized, Vulkan backend selected.")
+
+	// --- Create Vertex Buffer ---
+	vb_size := size_of(triangle_vertices)
+	log.infof("Attempting to create vertex buffer of size %d bytes.", vb_size)
+	vertex_buffer, vb_err := gfx.gfx_api.create_buffer(
+		gfx_device,
+		.Vertex,
+		vb_size,
+		&triangle_vertices[0],
+		false, // dynamic = false
+	)
+	if vb_err != .None {
+		log.errorf("Failed to create vertex buffer: %s", gfx.gfx_api.get_error_string(vb_err))
+		return
+	}
+	if vertex_buffer.variant == nil {
+		log.error("Vertex buffer creation returned success but handle is nil.")
+		return
+	}
+	defer gfx.gfx_api.destroy_buffer(vertex_buffer)
+	log.info("Vertex buffer created successfully.")
+
+	// --- Load Shaders ---
+	// Shader file paths (adjust if needed, assuming execution from example root or shaders are findable)
+	// For simplicity, assume execution from `examples/simple_vulkan_triangle/` or that paths are relative to it.
+	// Or, use absolute paths or a more robust path finding mechanism.
+	// Let's assume files are in "./shaders/" relative to executable for now.
+	vert_shader_path := "shaders/simple_triangle.vert"
+	frag_shader_path := "shaders/simple_triangle.frag"
+
+	vert_shader_source, ok_vs := read_shader_file(vert_shader_path)
+	if !ok_vs { return }
+	defer delete(vert_shader_source) // Free the string data if read_shader_file used non-context allocator
+
+	frag_shader_source, ok_fs := read_shader_file(frag_shader_path)
+	if !ok_fs { return }
+	defer delete(frag_shader_source)
+
+	log.info("Read shader sources.")
+
+	vert_shader, vs_err := gfx.gfx_api.create_shader_from_source(gfx_device, vert_shader_source, .Vertex)
+	if vs_err != .None {
+		log.errorf("Failed to create vertex shader: %s", gfx.gfx_api.get_error_string(vs_err))
+		if vs_err == .Shader_Compilation_Failed {
+			log.warn("Shader compilation failed. This might be due to shaderc not being found or a GLSL error.")
+		}
+		return
+	}
+	if vert_shader.variant == nil { log.error("Vertex shader creation success but handle is nil."); return }
+	defer gfx.gfx_api.destroy_shader(vert_shader)
+	log.info("Vertex shader created successfully.")
+
+	frag_shader, fs_err := gfx.gfx_api.create_shader_from_source(gfx_device, frag_shader_source, .Fragment)
+	if fs_err != .None {
+		log.errorf("Failed to create fragment shader: %s", gfx.gfx_api.get_error_string(fs_err))
+		if fs_err == .Shader_Compilation_Failed {
+			log.warn("Shader compilation failed. This might be due to shaderc not being found or a GLSL error.")
+		}
+		return
+	}
+	if frag_shader.variant == nil { log.error("Fragment shader creation success but handle is nil."); return }
+	defer gfx.gfx_api.destroy_shader(frag_shader)
+	log.info("Fragment shader created successfully.")
+
+	// --- Create Vertex Array (VAO) ---
+	vertex_attributes: []gfx.Vertex_Attribute = {
+		{ // Position
+			location = 0,
+			buffer_binding = 0,
+			format = .Float32_X2,
+			offset_in_bytes = offset_of(Vertex, pos),
+		},
+		{ // Color
+			location = 1,
+			buffer_binding = 0,
+			format = .Float32_X3,
+			offset_in_bytes = offset_of(Vertex, col),
+		},
+	}
+	
+	vertex_buffer_layouts: []gfx.Vertex_Buffer_Layout = {
+		{
+			binding = 0,
+			stride_in_bytes = size_of(Vertex),
+			attributes = vertex_attributes,
+			// step_rate = .Vertex // Assuming default is per-vertex
+		},
+	}
+
+	// For create_vertex_array, vertex_buffers is an array of Gfx_Buffer.
+	// Since we have one layout for binding 0, we provide one buffer.
+	vao_vertex_buffers := [1]gfx.Gfx_Buffer{vertex_buffer}
+
+	vao, vao_err := gfx.gfx_api.create_vertex_array(
+		gfx_device,
+		vertex_buffer_layouts[:],
+		vao_vertex_buffers[:],
+		gfx.Gfx_Buffer{}, // No index buffer
+	)
+	if vao_err != .None {
+		log.errorf("Failed to create VAO: %s", gfx.gfx_api.get_error_string(vao_err))
+		return
+	}
+	if vao.variant == nil { log.error("VAO creation success but handle is nil."); return }
+	defer gfx.gfx_api.destroy_vertex_array(vao)
+	log.info("VAO created successfully.")
+
+	// --- Create Pipeline ---
+	// Bind VAO first so pipeline can be created with its vertex input layout.
+	gfx.gfx_api.bind_vertex_array(gfx_device, vao) 
+	
+	pipeline_shaders := [2]gfx.Gfx_Shader{vert_shader, frag_shader}
+	pipeline, pipe_err := gfx.gfx_api.create_pipeline(gfx_device, pipeline_shaders[:])
+	if pipe_err != .None {
+		log.errorf("Failed to create pipeline: %s", gfx.gfx_api.get_error_string(pipe_err))
+		return
+	}
+	if pipeline.variant == nil { log.error("Pipeline creation success but handle is nil."); return }
+	defer gfx.gfx_api.destroy_pipeline(pipeline)
+	log.info("Graphics pipeline created successfully.")
+
+	// Unbind VAO after pipeline creation (optional, good practice if state might change)
+	// gfx.gfx_api.bind_vertex_array(gfx_device, gfx.Gfx_Vertex_Array{})
+
+
+	// --- Main Loop ---
+	log.info("Starting main loop...")
+	running := true
+	for running {
+		// Event Polling
+		core.poll_events()
+		// Check if window should close (e.g., user clicks X)
+		if core.window_should_close(main_window) {
+			running = false
+			continue
+		}
+		
+		// Frame Pacing / Timing (not implemented here for simplicity)
+
+		// Begin Frame
+		gfx.gfx_api.begin_frame(gfx_device) // For Vulkan, this acquires image and starts command buffer
+
+		// Get Drawable Size for Viewport/Scissor
+		drawable_w, drawable_h := gfx.gfx_api.get_window_drawable_size(main_window)
+		if drawable_w == 0 || drawable_h == 0 {
+			// Window might be minimized, skip rendering this frame.
+			// end_frame and present should still be called to keep frame sync logic happy.
+			gfx.gfx_api.end_frame(gfx_device)
+			// Present might not be strictly necessary if nothing rendered, but for Vulkan sync, it's safer.
+			gfx.gfx_api.present_window(main_window) 
+			continue 
+		}
+
+		viewport := gfx.Viewport{
+			x = 0, y = 0,
+			width = f32(drawable_w), height = f32(drawable_h),
+			min_depth = 0.0, max_depth = 1.0,
+		}
+		scissor := gfx.Scissor{
+			x = 0, y = 0,
+			width = i32(drawable_w), height = i32(drawable_h),
+		}
+
+		gfx.gfx_api.set_viewport(gfx_device, viewport)
+		gfx.gfx_api.set_scissor(gfx_device, scissor)
+
+		clear_opts := gfx.default_clear_options()
+		clear_opts.color = {0.1, 0.1, 0.1, 1.0}
+		gfx.gfx_api.clear_screen(gfx_device, clear_opts)
+
+		gfx.gfx_api.set_pipeline(gfx_device, pipeline)
+		
+		// Bind VAO (sets up which vertex layout is expected by pipeline state for draw)
+		gfx.gfx_api.bind_vertex_array(gfx_device, vao) 
+		
+		// Bind the actual vertex buffer to binding point 0 (as defined in VAO layout)
+		// The VAO itself doesn't bind buffers in Vulkan, it just describes layout.
+		// This call tells Vulkan which actual VkBuffer to use for which binding.
+		gfx.gfx_api.set_vertex_buffer(gfx_device, vertex_buffer, 0, 0)
+		// No index buffer to bind for this example.
+
+		gfx.gfx_api.draw(gfx_device, vertex_count=3, instance_count=1, first_vertex=0, first_instance=0)
+
+		gfx.gfx_api.end_frame(gfx_device)   // For Vulkan, this ends command buffer and submits
+		gfx.gfx_api.present_window(main_window)
+	}
+	log.info("Main loop ended.")
+
+	// Cleanup is handled by defers.
+	log.info("Shutting down Simple Vulkan Triangle Example.")
+}

--- a/examples/simple_vulkan_triangle/shaders/simple_triangle.vert
+++ b/examples/simple_vulkan_triangle/shaders/simple_triangle.vert
@@ -1,0 +1,8 @@
+#version 450
+layout(location = 0) in vec2 v_Pos;
+layout(location = 1) in vec3 v_Col;
+layout(location = 0) out vec3 f_Col;
+void main() {
+    gl_Position = vec4(v_Pos, 0.0, 1.0);
+    f_Col = v_Col;
+}

--- a/odingame/graphics/gfx_interface.odin
+++ b/odingame/graphics/gfx_interface.odin
@@ -87,14 +87,17 @@ Gfx_Window :: struct_variant {
 
 Gfx_Shader :: struct_variant {
 	// e.g. opengl: ^Gl_Shader
+	vulkan: ^rawptr, // Will hold ^vulkan.Vk_Shader_Internal
 }
 
 Gfx_Pipeline :: struct_variant {
     // e.g. opengl: ^Gl_Pipeline
+	vulkan: ^rawptr, // Will hold ^vulkan.Vk_Pipeline_Internal
 }
 
 Gfx_Buffer :: struct_variant {
 	// e.g. opengl: ^Gl_Buffer
+	vulkan: ^rawptr, // Will hold ^vulkan.Vk_Buffer_Internal
 }
 
 Gfx_Texture :: struct_variant {
@@ -193,6 +196,7 @@ Gfx_Device_Interface :: struct #ordered {
 	}
 
 	Gfx_Vertex_Array :: struct_variant { // e.g. opengl: ^Gl_Vertex_Array
+		vulkan: ^rawptr, // Will hold ^vulkan.Vk_Vertex_Array_Internal
 	}
 
 	// Creates a VAO. For OpenGL, this encapsulates VBO bindings, EBO binding, and vertex attribute pointers.

--- a/odingame/graphics/vulkan/vk_backend.odin
+++ b/odingame/graphics/vulkan/vk_backend.odin
@@ -3,45 +3,316 @@ package vulkan
 import "../gfx_interface"
 import "core:log"
 
+// --- Shader Management Wrappers ---
+
+// vk_create_shader_from_bytecode_wrapper calls the internal implementation.
+vk_create_shader_from_bytecode_wrapper :: proc(
+	device: gfx_interface.Gfx_Device, 
+	bytecode: []u8, 
+	stage: gfx_interface.Shader_Stage,
+) -> (gfx_interface.Gfx_Shader, gfx_interface.Gfx_Error) {
+	return vk_create_shader_from_bytecode_internal(device, bytecode, stage)
+}
+
+// vk_destroy_shader_wrapper calls the internal implementation.
+vk_destroy_shader_wrapper :: proc(shader: gfx_interface.Gfx_Shader) {
+	vk_destroy_shader_internal(shader)
+}
+
+// vk_create_shader_from_source_wrapper calls the internal implementation.
+vk_create_shader_from_source_wrapper :: proc(
+	device: gfx_interface.Gfx_Device, 
+	source: string, 
+	stage: gfx_interface.Shader_Stage,
+) -> (gfx_interface.Gfx_Shader, gfx_interface.Gfx_Error) {
+	// This will call the vk_shader.odin internal function which attempts shaderc compilation.
+	// If shaderc is not implemented/available, that internal function will return .Not_Implemented.
+	return vk_create_shader_from_source_internal(device, source, stage)
+}
+
+
 // --- Stub Implementations for Vulkan ---
 // These functions will be assigned to gfx_api for features not yet implemented in Vulkan.
 
-vk_stub_create_shader_from_source :: proc(device: gfx_interface.Gfx_Device, source: string, stage: gfx_interface.Shader_Stage) -> (gfx_interface.Gfx_Shader, gfx_interface.Gfx_Error) {
-	log.warn("Vulkan: create_shader_from_source not implemented.")
-	return gfx_interface.Gfx_Shader{}, .Not_Implemented
+// Stubs for functions other than device, window, and shader management (as per current task focus)
+// vk_stub_create_shader_from_source, vk_stub_create_shader_from_bytecode, vk_stub_destroy_shader
+// are now replaced by wrappers above.
+
+
+// --- Pipeline Management Wrappers ---
+
+vk_create_pipeline_wrapper :: proc(
+	device: gfx_interface.Gfx_Device, 
+	shaders: []gfx_interface.Gfx_Shader,
+	// vertex_input_state is not part of Gfx_Device_Interface.create_pipeline yet.
+	// The internal pipeline creation will use a default empty vertex input state.
+) -> (gfx_interface.Gfx_Pipeline, gfx_interface.Gfx_Error) {
+	
+	vk_dev_internal, ok_dev := device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev_internal == nil {
+		log.error("vk_create_pipeline_wrapper: Invalid Gfx_Device (not Vulkan or nil variant).")
+		return gfx_interface.Gfx_Pipeline{}, .Invalid_Handle
+	}
+
+	if vk_dev_internal.primary_window_for_pipeline == nil {
+		log.error("vk_create_pipeline_wrapper: No primary window associated with the device. Cannot determine swapchain format for render pass.")
+		// This indicates a design dependency: pipeline creation currently needs a window context for the render pass.
+		return gfx_interface.Gfx_Pipeline{}, .Invalid_Handle // Or .Initialization_Failed / .Not_Ready
+	}
+	primary_window := vk_dev_internal.primary_window_for_pipeline
+	swapchain_format := primary_window.swapchain_format 
+	// Ensure primary_window is valid and its swapchain_format is initialized.
+	// This would be vk.FORMAT_UNDEFINED if the window/swapchain isn't fully set up.
+	if swapchain_format == .UNDEFINED {
+		log.errorf("vk_create_pipeline_wrapper: Primary window (SDL: %s) has an undefined swapchain format.", sdl.GetWindowTitle(primary_window.sdl_window))
+		return gfx_interface.Gfx_Pipeline{}, .Device_Creation_Failed // Indicate device/window not ready
+	}
+
+	log.infof("Creating Vulkan pipeline using swapchain format %v from primary window (SDL: %s)", 
+		swapchain_format, sdl.GetWindowTitle(primary_window.sdl_window))
+
+	// 1. Create Render Pass
+	// The render pass is specific to the swapchain format.
+	render_pass_handle, rp_err := vk_create_render_pass_internal(vk_dev_internal.logical_device, swapchain_format)
+	if rp_err != .None {
+		log.errorf("Failed to create render pass for pipeline: %s", gfx_interface.gfx_api.get_error_string(rp_err))
+		return gfx_interface.Gfx_Pipeline{}, rp_err
+	}
+	// Defer its destruction only if subsequent steps fail and it's not passed to Vk_Pipeline_Internal.
+	// If pipeline creation succeeds, Vk_Pipeline_Internal will own it.
+
+	// 2. Create Pipeline Layout
+	pipeline_layout_handle, pl_err := vk_create_pipeline_layout_internal(vk_dev_internal.logical_device)
+	if pl_err != .None {
+		log.errorf("Failed to create pipeline layout for pipeline: %s", gfx_interface.gfx_api.get_error_string(pl_err))
+		// Cleanup render pass if layout creation failed
+		vk.DestroyRenderPass(vk_dev_internal.logical_device, render_pass_handle, nil)
+		return gfx_interface.Gfx_Pipeline{}, pl_err
+	}
+	// Defer its destruction similarly.
+
+	// 3. Create the Graphics Pipeline
+	// The vertex_input_state is handled internally by vk_create_pipeline_internal for now.
+
+	// Get vertex input state from active VAO, if any
+	vertex_bindings_slice: []Vk_Vertex_Input_Binding_Description
+	vertex_attributes_slice: []Vk_Vertex_Input_Attribute_Description
+
+	if primary_window.active_vao.variant != nil {
+		if vk_vao_internal, ok_vao_internal := primary_window.active_vao.variant.(^Vk_Vertex_Array_Internal); ok_vao_internal && vk_vao_internal != nil {
+			log.debugf("Using vertex input state from active VAO %p for pipeline creation.", vk_vao_internal)
+			vertex_bindings_slice = vk_vao_internal.binding_descriptions[:]
+			vertex_attributes_slice = vk_vao_internal.attribute_descriptions[:]
+		} else {
+			log.warnf("Active VAO variant is not of type ^Vk_Vertex_Array_Internal. Type: %T. Using empty vertex input state.", primary_window.active_vao.variant)
+			// Fallthrough to use empty slices
+		}
+	} else {
+		log.debug("No active VAO found. Using empty vertex input state for pipeline creation.")
+		// Fallthrough to use empty slices (already initialized as nil/empty)
+	}
+	
+	gfx_pipeline, pipe_err := vk_create_pipeline_internal(
+		device, 
+		shaders, 
+		render_pass_handle, 
+		pipeline_layout_handle,
+		vertex_bindings_slice,    // Pass VAO bindings
+		vertex_attributes_slice,  // Pass VAO attributes
+	)
+
+	if pipe_err != .None {
+		log.errorf("Core graphics pipeline creation failed: %s", gfx_interface.gfx_api.get_error_string(pipe_err))
+		// Cleanup render pass and pipeline layout as they were not successfully transferred to Vk_Pipeline_Internal
+		vk.DestroyPipelineLayout(vk_dev_internal.logical_device, pipeline_layout_handle, nil)
+		vk.DestroyRenderPass(vk_dev_internal.logical_device, render_pass_handle, nil)
+		return gfx_interface.Gfx_Pipeline{}, pipe_err
+	}
+
+	// If successful, render_pass_handle and pipeline_layout_handle are now owned by the Vk_Pipeline_Internal
+	// instance within gfx_pipeline.
+	log.info("Vulkan pipeline wrapper created successfully.")
+	return gfx_pipeline, .None
 }
-vk_stub_create_shader_from_bytecode :: proc(device: gfx_interface.Gfx_Device, bytecode: []u8, stage: gfx_interface.Shader_Stage) -> (gfx_interface.Gfx_Shader, gfx_interface.Gfx_Error) {
-	log.warn("Vulkan: create_shader_from_bytecode not implemented.")
-	return gfx_interface.Gfx_Shader{}, .Not_Implemented
+
+vk_destroy_pipeline_wrapper :: proc(pipeline: gfx_interface.Gfx_Pipeline) {
+	vk_destroy_pipeline_internal(pipeline) // This will handle destroying pipeline, layout, and render_pass
 }
-vk_stub_destroy_shader :: proc(shader: gfx_interface.Gfx_Shader) {
-	log.warn("Vulkan: destroy_shader not implemented.")
+
+// --- Buffer Management Wrappers ---
+
+vk_create_buffer_wrapper :: proc(
+	device: gfx_interface.Gfx_Device, 
+	type: gfx_interface.Buffer_Type, 
+	size: int, 
+	data: rawptr = nil, 
+	dynamic: bool = false,
+) -> (gfx_interface.Gfx_Buffer, gfx_interface.Gfx_Error) {
+	return vk_create_buffer_internal(device, type, size, data, dynamic)
 }
-vk_stub_create_pipeline :: proc(device: gfx_interface.Gfx_Device, shaders: []gfx_interface.Gfx_Shader) -> (gfx_interface.Gfx_Pipeline, gfx_interface.Gfx_Error) {
-	log.warn("Vulkan: create_pipeline not implemented.")
-	return gfx_interface.Gfx_Pipeline{}, .Not_Implemented
+
+vk_destroy_buffer_wrapper :: proc(buffer: gfx_interface.Gfx_Buffer) {
+	vk_destroy_buffer_internal(buffer)
 }
-vk_stub_destroy_pipeline :: proc(pipeline: gfx_interface.Gfx_Pipeline) {
-	log.warn("Vulkan: destroy_pipeline not implemented.")
+
+vk_map_buffer_wrapper :: proc(buffer: gfx_interface.Gfx_Buffer, offset, size: int) -> rawptr {
+	return vk_map_buffer_internal(buffer, offset, size)
 }
-vk_stub_create_buffer :: proc(device: gfx_interface.Gfx_Device, type: gfx_interface.Buffer_Type, size: int, data: rawptr = nil, dynamic: bool = false) -> (gfx_interface.Gfx_Buffer, gfx_interface.Gfx_Error) {
-	log.warn("Vulkan: create_buffer not implemented.")
-	return gfx_interface.Gfx_Buffer{}, .Not_Implemented
+
+vk_unmap_buffer_wrapper :: proc(buffer: gfx_interface.Gfx_Buffer) {
+	vk_unmap_buffer_internal(buffer)
 }
-vk_stub_update_buffer :: proc(buffer: gfx_interface.Gfx_Buffer, offset: int, data: rawptr, size: int) -> gfx_interface.Gfx_Error {
-	log.warn("Vulkan: update_buffer not implemented.")
-	return .Not_Implemented
+
+// vk_update_buffer_wrapper: For Vulkan, if a buffer is not persistently mapped and HOST_COHERENT,
+// this would involve mapping, copying data, and unmapping.
+// If it's DEVICE_LOCAL, it would involve a staging buffer and command buffer operations.
+// For now, this will be a simplified version or a stub.
+// Let's assume it behaves like initial data upload: map, copy, unmap.
+vk_update_buffer_wrapper :: proc(buffer_handle_gfx: gfx_interface.Gfx_Buffer, offset: int, data: rawptr, size: int) -> gfx_interface.Gfx_Error {
+	vk_buffer_ptr, ok_buf := buffer_handle_gfx.variant.(^Vk_Buffer_Internal)
+	if !ok_buf || vk_buffer_ptr == nil {
+		log.errorf("vk_update_buffer: Invalid Gfx_Buffer type or nil variant (%v).", buffer_handle_gfx.variant)
+		return .Invalid_Handle
+	}
+	buffer_internal := vk_buffer_ptr^
+	logical_device := buffer_internal.device_ref.logical_device
+
+	if data == nil || size <= 0 {
+		log.error("vk_update_buffer: Invalid data or size for update.")
+		return .Invalid_Handle // Or specific error code
+	}
+	if offset < 0 || vk.DeviceSize(offset + size) > buffer_internal.size {
+		log.errorf("vk_update_buffer: Offset (%d) / Size (%d) out of bounds for buffer of size %v.", offset, size, buffer_internal.size)
+		return .Invalid_Handle // Or specific error code
+	}
+
+	// Assuming HOST_VISIBLE and HOST_COHERENT memory for simplicity
+	log.debugf("Updating buffer %p, Offset %d, Size %d", buffer_internal.buffer, offset, size)
+	mapped_data_ptr: rawptr
+	map_result := vk.MapMemory(logical_device, buffer_internal.memory, vk.DeviceSize(offset), vk.DeviceSize(size), 0, &mapped_data_ptr)
+	if map_result == .SUCCESS && mapped_data_ptr != nil {
+		mem.copy(mapped_data_ptr, data, size)
+		// HOST_COHERENT ensures visibility. If not coherent, flush would be needed.
+		vk.UnmapMemory(logical_device, buffer_internal.memory)
+		log.debug("Buffer update successful via map/copy/unmap.")
+		return .None
+	} else {
+		log.errorf("vkMapMemory failed for buffer update. Result: %v", map_result)
+		return .Buffer_Creation_Failed // Or a more specific "Update_Failed"
+	}
 }
-vk_stub_destroy_buffer :: proc(buffer: gfx_interface.Gfx_Buffer) {
-	log.warn("Vulkan: destroy_buffer not implemented.")
+
+
+// --- Frame Management and Drawing Command Wrappers ---
+
+// vk_begin_frame_wrapper: Operates on the device's primary window.
+vk_begin_frame_wrapper :: proc(device: gfx_interface.Gfx_Device) {
+	vk_dev, ok_dev := device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev == nil { log.error("vk_begin_frame_wrapper: Invalid Gfx_Device."); return }
+	
+	primary_window_ptr := vk_dev.primary_window_for_pipeline
+	if primary_window_ptr == nil { 
+		log.error("vk_begin_frame_wrapper: No primary window set on device for frame operations.")
+		return 
+	}
+	primary_gfx_window := gfx_interface.Gfx_Window{variant = primary_window_ptr}
+	
+	ok, _, _ := vk_begin_frame_internal(primary_gfx_window)
+	if !ok {
+		log.warn("vk_begin_frame_wrapper: vk_begin_frame_internal indicated an issue (e.g. swapchain out of date).")
+	}
 }
-vk_stub_map_buffer :: proc(buffer: gfx_interface.Gfx_Buffer, offset, size: int) -> rawptr {
-    log.warn("Vulkan: map_buffer not implemented.")
-    return nil
+
+// vk_end_frame_wrapper: Operates on the device's primary window.
+vk_end_frame_wrapper :: proc(device: gfx_interface.Gfx_Device) {
+	vk_dev, ok_dev := device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev == nil { log.error("vk_end_frame_wrapper: Invalid Gfx_Device."); return }
+
+	primary_window_ptr := vk_dev.primary_window_for_pipeline
+	if primary_window_ptr == nil { 
+		log.error("vk_end_frame_wrapper: No primary window set on device for frame operations.")
+		return 
+	}
+	primary_gfx_window := gfx_interface.Gfx_Window{variant = primary_window_ptr}
+
+	if !vk_end_frame_internal(primary_gfx_window) {
+		log.warn("vk_end_frame_wrapper: vk_end_frame_internal indicated an issue (e.g. swapchain out of date or present failed).")
+	}
 }
-vk_stub_unmap_buffer :: proc(buffer: gfx_interface.Gfx_Buffer) {
-    log.warn("Vulkan: unmap_buffer not implemented.")
+
+// vk_clear_screen_wrapper: Operates on the device's primary window.
+// It uses the window's main render pass.
+vk_clear_screen_wrapper :: proc(device: gfx_interface.Gfx_Device, options: gfx_interface.Clear_Options) {
+	vk_dev, ok_dev := device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev == nil { log.error("vk_clear_screen_wrapper: Invalid Gfx_Device."); return }
+	
+	primary_window_ptr := vk_dev.primary_window_for_pipeline
+	if primary_window_ptr == nil { log.error("vk_clear_screen_wrapper: No primary window."); return }
+	if primary_window_ptr.active_command_buffer == vk.NULL_HANDLE { log.error("vk_clear_screen_wrapper: No active command buffer on primary window."); return }
+
+	primary_gfx_window := gfx_interface.Gfx_Window{variant = primary_window_ptr}
+	vk_clear_screen_internal(primary_gfx_window, options)
 }
+
+
+vk_set_viewport_wrapper :: proc(device: gfx_interface.Gfx_Device, viewport: gfx_interface.Viewport) {
+	vk_dev, ok_dev := device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev == nil { log.error("vk_set_viewport_wrapper: Invalid Gfx_Device."); return }
+	primary_window_ptr := vk_dev.primary_window_for_pipeline
+	if primary_window_ptr == nil || primary_window_ptr.active_command_buffer == vk.NULL_HANDLE { 
+		log.error("vk_set_viewport_wrapper: No primary window or active command buffer.")
+		return 
+	}
+	vk_set_viewport_internal(primary_window_ptr.active_command_buffer, viewport)
+}
+
+vk_set_scissor_wrapper :: proc(device: gfx_interface.Gfx_Device, scissor: gfx_interface.Scissor) {
+	vk_dev, ok_dev := device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev == nil { log.error("vk_set_scissor_wrapper: Invalid Gfx_Device."); return }
+	primary_window_ptr := vk_dev.primary_window_for_pipeline
+	if primary_window_ptr == nil || primary_window_ptr.active_command_buffer == vk.NULL_HANDLE { 
+		log.error("vk_set_scissor_wrapper: No primary window or active command buffer.")
+		return 
+	}
+	vk_set_scissor_internal(primary_window_ptr.active_command_buffer, scissor)
+}
+
+vk_set_pipeline_wrapper :: proc(device: gfx_interface.Gfx_Device, pipeline: gfx_interface.Gfx_Pipeline) {
+	vk_dev, ok_dev := device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev == nil { log.error("vk_set_pipeline_wrapper: Invalid Gfx_Device."); return }
+	primary_window_ptr := vk_dev.primary_window_for_pipeline
+	if primary_window_ptr == nil { 
+		log.error("vk_set_pipeline_wrapper: No primary window for context.")
+		return 
+	}
+	// active_command_buffer check is implicitly done by vk_set_pipeline_internal
+	primary_gfx_window := gfx_interface.Gfx_Window{variant = primary_window_ptr}
+	vk_set_pipeline_internal(primary_gfx_window, pipeline)
+}
+
+vk_set_vertex_buffer_wrapper :: proc(device: gfx_interface.Gfx_Device, buffer: gfx_interface.Gfx_Buffer, binding_index: u32 = 0, offset: u32 = 0) {
+	vk_dev, ok_dev := device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev == nil { log.error("vk_set_vertex_buffer_wrapper: Invalid Gfx_Device."); return }
+	primary_window_ptr := vk_dev.primary_window_for_pipeline
+	if primary_window_ptr == nil || primary_window_ptr.active_command_buffer == vk.NULL_HANDLE { 
+		log.error("vk_set_vertex_buffer_wrapper: No primary window or active command buffer.")
+		return 
+	}
+	vk_set_vertex_buffer_internal(primary_window_ptr.active_command_buffer, buffer, binding_index, offset)
+}
+
+vk_draw_wrapper :: proc(device: gfx_interface.Gfx_Device, vertex_count, instance_count, first_vertex, first_instance: u32) {
+	vk_dev, ok_dev := device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev == nil { log.error("vk_draw_wrapper: Invalid Gfx_Device."); return }
+	primary_window_ptr := vk_dev.primary_window_for_pipeline
+	if primary_window_ptr == nil || primary_window_ptr.active_command_buffer == vk.NULL_HANDLE { 
+		log.error("vk_draw_wrapper: No primary window or active command buffer.")
+		return 
+	}
+	vk_draw_internal(primary_window_ptr.active_command_buffer, vertex_count, instance_count, first_vertex, first_instance)
+}
+
+// Stubs for remaining functions
 vk_stub_create_texture :: proc(device: gfx_interface.Gfx_Device, width, height: int, format: gfx_interface.Texture_Format, usage: gfx_interface.Texture_Usage, data: rawptr = nil) -> (gfx_interface.Gfx_Texture, gfx_interface.Gfx_Error) {
 	log.warn("Vulkan: create_texture not implemented.")
 	return gfx_interface.Gfx_Texture{}, .Not_Implemented
@@ -52,27 +323,6 @@ vk_stub_update_texture :: proc(texture: gfx_interface.Gfx_Texture, x, y, width, 
 }
 vk_stub_destroy_texture :: proc(texture: gfx_interface.Gfx_Texture) {
 	log.warn("Vulkan: destroy_texture not implemented.")
-}
-vk_stub_begin_frame :: proc(device: gfx_interface.Gfx_Device) {
-	log.debug("Vulkan: begin_frame (stub).") // Debug as it might be called frequently
-}
-vk_stub_end_frame :: proc(device: gfx_interface.Gfx_Device) {
-	log.debug("Vulkan: end_frame (stub).")
-}
-vk_stub_clear_screen :: proc(device: gfx_interface.Gfx_Device, options: gfx_interface.Clear_Options) {
-	log.warn("Vulkan: clear_screen not implemented.")
-}
-vk_stub_set_viewport :: proc(device: gfx_interface.Gfx_Device, viewport: gfx_interface.Viewport) {
-    log.warn("Vulkan: set_viewport not implemented.")
-}
-vk_stub_set_scissor :: proc(device: gfx_interface.Gfx_Device, scissor: gfx_interface.Scissor) {
-    log.warn("Vulkan: set_scissor not implemented.")
-}
-vk_stub_set_pipeline :: proc(device: gfx_interface.Gfx_Device, pipeline: gfx_interface.Gfx_Pipeline) {
-	log.warn("Vulkan: set_pipeline not implemented.")
-}
-vk_stub_set_vertex_buffer :: proc(device: gfx_interface.Gfx_Device, buffer: gfx_interface.Gfx_Buffer, binding_index: u32 = 0, offset: u32 = 0) {
-	log.warn("Vulkan: set_vertex_buffer not implemented.")
 }
 vk_stub_set_index_buffer :: proc(device: gfx_interface.Gfx_Device, buffer: gfx_interface.Gfx_Buffer, offset: u32 = 0) {
 	log.warn("Vulkan: set_index_buffer not implemented.")
@@ -123,12 +373,90 @@ vk_stub_get_texture_height :: proc(texture: gfx_interface.Gfx_Texture) -> int {
     log.warn("Vulkan: get_texture_height not implemented.")
     return 0
 }
-vk_stub_draw :: proc(device: gfx_interface.Gfx_Device, vertex_count, instance_count, first_vertex, first_instance: u32) {
-	log.warn("Vulkan: draw not implemented.")
-}
 vk_stub_draw_indexed :: proc(device: gfx_interface.Gfx_Device, index_count, instance_count, first_index, base_vertex, first_instance: u32) {
 	log.warn("Vulkan: draw_indexed not implemented.")
 }
+
+// --- VAO Management Wrappers ---
+
+vk_create_vertex_array_wrapper :: proc(
+    device: gfx_interface.Gfx_Device, 
+    vertex_buffer_layouts: []gfx_interface.Vertex_Buffer_Layout, 
+    vertex_buffers: []gfx_interface.Gfx_Buffer,
+    index_buffer: gfx_interface.Gfx_Buffer,
+) -> (gfx_interface.Gfx_Vertex_Array, gfx_interface.Gfx_Error) {
+	return vk_create_vertex_array_internal(device, vertex_buffer_layouts, vertex_buffers, index_buffer)
+}
+
+vk_destroy_vertex_array_wrapper :: proc(vao: gfx_interface.Gfx_Vertex_Array) {
+	vk_destroy_vertex_array_internal(vao)
+}
+
+// vk_bind_vertex_array_wrapper sets the active VAO on the primary window.
+vk_bind_vertex_array_wrapper :: proc(device: gfx_interface.Gfx_Device, vao_handle_gfx: gfx_interface.Gfx_Vertex_Array) {
+	vk_dev, ok_dev := device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev == nil { log.error("vk_bind_vertex_array_wrapper: Invalid Gfx_Device."); return }
+	
+	primary_window_ptr := vk_dev.primary_window_for_pipeline
+	if primary_window_ptr == nil { 
+		log.error("vk_bind_vertex_array_wrapper: No primary window set on device.")
+		return 
+	}
+	// active_cmd_buf := primary_window_ptr.active_command_buffer // Not needed for just setting the VAO handle
+
+	primary_window_ptr.active_vao = vao_handle_gfx
+	
+	if vao_handle_gfx.variant != nil {
+		if _, ok_vao_internal_ptr := vao_handle_gfx.variant.(^Vk_Vertex_Array_Internal); ok_vao_internal_ptr {
+			log.debugf("Set active VAO on window %p.", primary_window_ptr)
+		} else {
+			log.errorf("vk_bind_vertex_array_wrapper: Bound VAO has incorrect variant type: %T. Clearing active VAO.", vao_handle_gfx.variant)
+			primary_window_ptr.active_vao = gfx_interface.Gfx_Vertex_Array{} // Clear if invalid type
+		}
+	} else {
+		log.debugf("Cleared active VAO on window %p.", primary_window_ptr)
+	}
+	// Note: Actual vk.CmdBindVertexBuffers and vk.CmdBindIndexBuffer calls
+	// are performed by vk_set_vertex_buffer_wrapper and vk_set_index_buffer_wrapper.
+}
+
+// vk_set_index_buffer_wrapper binds the given index buffer.
+vk_set_index_buffer_wrapper :: proc(device: gfx_interface.Gfx_Device, buffer_gfx: gfx_interface.Gfx_Buffer, offset: u32 = 0) {
+	vk_dev, ok_dev := device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev == nil { log.error("vk_set_index_buffer_wrapper: Invalid Gfx_Device."); return }
+	
+	primary_window_ptr := vk_dev.primary_window_for_pipeline
+	if primary_window_ptr == nil { log.error("vk_set_index_buffer_wrapper: No primary window for context."); return }
+	
+	active_cmd_buf := primary_window_ptr.active_command_buffer
+	if active_cmd_buf == vk.NULL_HANDLE { log.error("vk_set_index_buffer_wrapper: No active command buffer."); return }
+
+	vk_buffer_internal, ok_buf_internal := buffer_gfx.variant.(^Vk_Buffer_Internal)
+	if !ok_buf_internal || vk_buffer_internal == nil {
+		log.error("vk_set_index_buffer_wrapper: Invalid Gfx_Buffer provided.")
+		return
+	}
+
+	// Determine index type. Default to UINT32.
+	// If an active VAO is present and its index buffer matches this one, use the VAO's index type.
+	index_type_to_bind := vk.IndexType.UINT32 // Default
+	if active_vao_ptr, ok_vao := primary_window_ptr.active_vao.variant.(^Vk_Vertex_Array_Internal); ok_vao && active_vao_ptr != nil {
+		// Check if the buffer being bound is the same as the one stored in the VAO
+		if active_vao_ib_ptr, ok_vao_ib := active_vao_ptr.index_buffer_gfx.variant.(^Vk_Buffer_Internal); ok_vao_ib && active_vao_ib_ptr == vk_buffer_internal {
+			index_type_to_bind = active_vao_ptr.index_type
+			log.debugf("Using index type %v from active VAO for index buffer %p.", index_type_to_bind, vk_buffer_internal.buffer)
+		} else {
+			log.debugf("Binding index buffer %p, but it does not match active VAO's index buffer. Defaulting to index type UINT32.", vk_buffer_internal.buffer)
+		}
+	} else {
+		log.debug("No active VAO or VAO has no index buffer. Defaulting to index type UINT32 for binding.")
+	}
+	
+	vk.CmdBindIndexBuffer(active_cmd_buf, vk_buffer_internal.buffer, vk.DeviceSize(offset), index_type_to_bind)
+	log.debugf("Bound index buffer %p with offset %d and type %v.", vk_buffer_internal.buffer, offset, index_type_to_bind)
+}
+
+
 vk_stub_get_error_string :: proc(error: gfx_interface.Gfx_Error) -> string {
     // This can use the same error string mapping as OpenGL backend, or a Vulkan specific one if needed.
     // For now, assume generic error strings.
@@ -160,22 +488,22 @@ initialize_vulkan_backend :: proc() {
 		get_window_size            = vk_get_window_size_wrapper,
 		get_window_drawable_size   = vk_get_window_drawable_size_wrapper,
 		
-		// Shader Management (Stubs)
-		create_shader_from_source  = vk_stub_create_shader_from_source,
-		create_shader_from_bytecode= vk_stub_create_shader_from_bytecode,
-		destroy_shader             = vk_stub_destroy_shader,
-        create_pipeline            = vk_stub_create_pipeline,
-        destroy_pipeline           = vk_stub_destroy_pipeline,
-        set_pipeline               = vk_stub_set_pipeline,
+		// Shader Management (Implemented via wrappers)
+		create_shader_from_source  = vk_create_shader_from_source_wrapper,
+		create_shader_from_bytecode= vk_create_shader_from_bytecode_wrapper,
+		destroy_shader             = vk_destroy_shader_wrapper,
+        create_pipeline            = vk_create_pipeline_wrapper, // Now implemented
+        destroy_pipeline           = vk_destroy_pipeline_wrapper, // Now implemented
+        set_pipeline               = vk_stub_set_pipeline, // Still a stub
 
-		// Buffer Management (Stubs)
-		create_buffer              = vk_stub_create_buffer,
-		update_buffer              = vk_stub_update_buffer,
-		destroy_buffer             = vk_stub_destroy_buffer,
-        map_buffer                 = vk_stub_map_buffer,
-        unmap_buffer               = vk_stub_unmap_buffer,
-		set_vertex_buffer          = vk_stub_set_vertex_buffer,
-		set_index_buffer           = vk_stub_set_index_buffer,
+		// Buffer Management (Implemented via wrappers)
+		create_buffer              = vk_create_buffer_wrapper,
+		update_buffer              = vk_update_buffer_wrapper, // Basic implementation
+		destroy_buffer             = vk_destroy_buffer_wrapper,
+        map_buffer                 = vk_map_buffer_wrapper,
+        unmap_buffer               = vk_unmap_buffer_wrapper,
+		set_vertex_buffer          = vk_set_vertex_buffer_wrapper, 
+		set_index_buffer           = vk_set_index_buffer_wrapper, // Now implemented
 
 		// Texture Management (Stubs)
 		create_texture             = vk_stub_create_texture,
@@ -204,10 +532,10 @@ initialize_vulkan_backend :: proc() {
 		set_uniform_int            = vk_stub_set_uniform_int,
 		set_uniform_float          = vk_stub_set_uniform_float,
 		
-		// VAO (Stubs)
-		create_vertex_array      = vk_stub_create_vertex_array,
-		destroy_vertex_array     = vk_stub_destroy_vertex_array,
-		bind_vertex_array        = vk_stub_bind_vertex_array,
+		// VAO (Implemented via wrappers)
+		create_vertex_array      = vk_create_vertex_array_wrapper,
+		destroy_vertex_array     = vk_destroy_vertex_array_wrapper,
+		bind_vertex_array        = vk_bind_vertex_array_wrapper,
 		
         // Utility (Stub, could share with GL or have specific error codes)
         get_error_string           = vk_stub_get_error_string,

--- a/odingame/graphics/vulkan/vk_buffer.odin
+++ b/odingame/graphics/vulkan/vk_buffer.odin
@@ -1,0 +1,315 @@
+package vulkan
+
+import vk "vendor:vulkan"
+import "core:log"
+import "core:mem"
+import "../gfx_interface" // For Gfx_Device, Gfx_Error, Gfx_Buffer, Buffer_Type
+
+// Vk_Buffer_Internal holds the Vulkan-specific buffer data.
+Vk_Buffer_Internal :: struct {
+	buffer:          vk.Buffer,
+	memory:          vk.DeviceMemory,
+	device_ref:      ^Vk_Device_Internal, // Reference to the logical device & physical device info
+	size:            vk.DeviceSize,     // Size of the buffer in bytes
+	allocator:       mem.Allocator,     // Allocator used for this struct
+	mapped_ptr:      rawptr,            // Pointer to mapped memory, if currently mapped
+	// For persistent mapping, one might store usage flags (host_visible, coherent, cached)
+}
+
+// find_memory_type_internal finds a suitable memory type index.
+find_memory_type_internal :: proc(
+	physical_device_handle: vk.PhysicalDevice,
+	type_filter: u32, // Bitmask of allowed memory type indices from vk.MemoryRequirements
+	properties: vk.MemoryPropertyFlags, // Required memory properties (e.g., HOST_VISIBLE, DEVICE_LOCAL)
+) -> (
+	memory_type_index: u32,
+	found: bool,
+) {
+	mem_properties: vk.PhysicalDeviceMemoryProperties
+	vk.GetPhysicalDeviceMemoryProperties(physical_device_handle, &mem_properties)
+
+	for i := u32(0); i < mem_properties.memoryTypeCount; i = i + 1 {
+		// Check if this memory type is allowed by the type_filter
+		if (type_filter & (1 << i)) != 0 {
+			// Check if this memory type has all the required properties
+			if (mem_properties.memoryTypes[i].propertyFlags & properties) == properties {
+				log.debugf("Found suitable memory type: Index %d, Flags %#x", i, mem_properties.memoryTypes[i].propertyFlags)
+				return i, true
+			}
+		}
+	}
+
+	log.errorf("Failed to find suitable memory type. Filter: %#x, Required Properties: %#x", type_filter, properties)
+	// Log available memory types for debugging
+	for i := u32(0); i < mem_properties.memoryTypeCount; i = i + 1 {
+		log.debugf("  Available Memory Type %d: Flags %#x, Heap Index %d", i, mem_properties.memoryTypes[i].propertyFlags, mem_properties.memoryTypes[i].heapIndex)
+		log.debugf("    Heap %d: Size %v bytes, Flags %#x", mem_properties.memoryTypes[i].heapIndex, mem_properties.memoryHeaps[mem_properties.memoryTypes[i].heapIndex].size, mem_properties.memoryHeaps[mem_properties.memoryTypes[i].heapIndex].flags)
+	}
+	return 0, false
+}
+
+
+// vk_create_buffer_internal creates a Vulkan buffer, allocates memory, and optionally uploads initial data.
+vk_create_buffer_internal :: proc(
+	gfx_device: gfx_interface.Gfx_Device,
+	buffer_type: gfx_interface.Buffer_Type,
+	size_bytes: int, // Renamed from 'size' to avoid conflict with Vk_Buffer_Internal.size
+	initial_data: rawptr,
+	dynamic: bool, // Hint for memory properties, though currently all are host-visible
+) -> (gfx_interface.Gfx_Buffer, gfx_interface.Gfx_Error) {
+
+	vk_dev_internal, ok_dev := gfx_device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev_internal == nil {
+		log.error("vk_create_buffer: Invalid Gfx_Device (not Vulkan or nil variant).")
+		return gfx_interface.Gfx_Buffer{}, .Invalid_Handle
+	}
+	logical_device := vk_dev_internal.logical_device
+	physical_device := vk_dev_internal.physical_device_info.physical_device
+	allocator := vk_dev_internal.allocator // Use device's allocator for the Vk_Buffer_Internal struct
+
+	if size_bytes <= 0 {
+		log.errorf("Buffer size must be positive. Requested: %d", size_bytes)
+		return gfx_interface.Gfx_Buffer{}, .Buffer_Creation_Failed // Or Invalid_Parameter
+	}
+
+	// 1. Determine Buffer Usage
+	usage_flags: vk.BufferUsageFlags
+	#partial switch buffer_type {
+	case .Vertex:
+		usage_flags |= {.VERTEX_BUFFER_BIT}
+	case .Index:
+		usage_flags |= {.INDEX_BUFFER_BIT}
+	case .Uniform:
+		usage_flags |= {.UNIFORM_BUFFER_BIT}
+	// case .Storage: usage_flags |= {.STORAGE_BUFFER_BIT} // For future
+	// case .Staging: usage_flags |= {.TRANSFER_SRC_BIT}   // For future
+	}
+	// If initial_data is provided, buffer might also need TRANSFER_DST_BIT if we used a staging buffer.
+	// For direct mapping, it's not strictly needed for the buffer itself.
+	log.debugf("Creating buffer: Type %v, Size %d bytes, UsageFlags %#x", buffer_type, size_bytes, usage_flags)
+
+	// 2. Create Buffer
+	buffer_create_info := vk.BufferCreateInfo{
+		sType = .BUFFER_CREATE_INFO,
+		size = vk.DeviceSize(size_bytes),
+		usage = usage_flags,
+		sharingMode = .EXCLUSIVE, // Assuming not sharing buffers between queue families for now
+		// flags can be .SPARSE_BINDING_BIT etc.
+	}
+	p_vk_allocator: ^vk.AllocationCallbacks = nil // Using nil for Vulkan allocation callbacks
+	buffer_handle: vk.Buffer
+	result := vk.CreateBuffer(logical_device, &buffer_create_info, p_vk_allocator, &buffer_handle)
+	if result != .SUCCESS {
+		log.errorf("vkCreateBuffer failed. Result: %v (%d)", result, int(result))
+		return gfx_interface.Gfx_Buffer{}, .Buffer_Creation_Failed
+	}
+	log.debugf("Vulkan Buffer created successfully: %p", buffer_handle)
+
+	// 3. Get Memory Requirements
+	mem_reqs: vk.MemoryRequirements
+	vk.GetBufferMemoryRequirements(logical_device, buffer_handle, &mem_reqs)
+	log.debugf("Buffer memory requirements: Size %v, Alignment %v, TypeFilter %#x", mem_reqs.size, mem_reqs.alignment, mem_reqs.memoryTypeBits)
+
+	// 4. Determine Memory Properties
+	// For now, all buffers are host-visible and coherent for simplicity with initial data upload and mapping.
+	// `dynamic` flag is a hint but not fully utilized yet to differentiate DEVICE_LOCAL.
+	// TODO: Use `DEVICE_LOCAL_BIT` for static buffers and implement staging buffer uploads.
+	mem_props: vk.MemoryPropertyFlags = {.HOST_VISIBLE_BIT, .HOST_COHERENT_BIT}
+	// if !dynamic && initial_data != nil { 
+	//    mem_props = {.DEVICE_LOCAL_BIT} // Ideal for static data, would require staging
+	// }
+
+	// 5. Find Suitable Memory Type
+	memory_type_idx, found_mem_type := find_memory_type_internal(physical_device, mem_reqs.memoryTypeBits, mem_props)
+	if !found_mem_type {
+		log.error("Failed to find suitable memory type for buffer.")
+		vk.DestroyBuffer(logical_device, buffer_handle, p_vk_allocator) // Cleanup created buffer
+		return gfx_interface.Gfx_Buffer{}, .Buffer_Creation_Failed
+	}
+
+	// 6. Allocate Memory
+	alloc_info := vk.MemoryAllocateInfo{
+		sType = .MEMORY_ALLOCATE_INFO,
+		allocationSize = mem_reqs.size, // Use reported size from mem_reqs
+		memoryTypeIndex = memory_type_idx,
+	}
+	device_memory: vk.DeviceMemory
+	result = vk.AllocateMemory(logical_device, &alloc_info, p_vk_allocator, &device_memory)
+	if result != .SUCCESS {
+		log.errorf("vkAllocateMemory failed for buffer. Result: %v (%d)", result, int(result))
+		vk.DestroyBuffer(logical_device, buffer_handle, p_vk_allocator) // Cleanup
+		return gfx_interface.Gfx_Buffer{}, .Buffer_Creation_Failed
+	}
+	log.debugf("Device memory allocated for buffer: %p (Size: %v, TypeIndex: %d)", device_memory, mem_reqs.size, memory_type_idx)
+
+	// 7. Bind Buffer Memory
+	// The offset for binding is usually 0.
+	result = vk.BindBufferMemory(logical_device, buffer_handle, device_memory, 0)
+	if result != .SUCCESS {
+		log.errorf("vkBindBufferMemory failed. Result: %v (%d)", result, int(result))
+		vk.FreeMemory(logical_device, device_memory, p_vk_allocator) // Cleanup
+		vk.DestroyBuffer(logical_device, buffer_handle, p_vk_allocator) // Cleanup
+		return gfx_interface.Gfx_Buffer{}, .Buffer_Creation_Failed
+	}
+	log.debug("Memory bound to buffer successfully.")
+
+	// 8. Upload Initial Data (if provided)
+	if initial_data != nil {
+		log.debugf("Uploading initial data to buffer %p (%d bytes)...", buffer_handle, size_bytes)
+		mapped_data_ptr: rawptr
+		// Map the entire buffer for simplicity (offset 0, size buffer_create_info.size).
+		map_result := vk.MapMemory(logical_device, device_memory, 0, buffer_create_info.size, 0, &mapped_data_ptr)
+		if map_result == .SUCCESS && mapped_data_ptr != nil {
+			mem.copy(mapped_data_ptr, initial_data, int(size_bytes))
+			// HOST_COHERENT_BIT ensures writes are visible without explicit flush, assuming it's set.
+			// If not coherent, would need:
+			// flushed_range := vk.MappedMemoryRange{ sType = .MAPPED_MEMORY_RANGE, memory = device_memory, offset = 0, size = vk.WHOLE_SIZE }
+			// vk.FlushMappedMemoryRanges(logical_device, 1, &flushed_range)
+			vk.UnmapMemory(logical_device, device_memory)
+			log.debug("Initial data uploaded and memory unmapped.")
+		} else {
+			log.errorf("vkMapMemory failed for initial data upload. Result: %v", map_result)
+			// Cleanup everything as upload failed
+			vk.FreeMemory(logical_device, device_memory, p_vk_allocator)
+			vk.DestroyBuffer(logical_device, buffer_handle, p_vk_allocator)
+			return gfx_interface.Gfx_Buffer{}, .Buffer_Creation_Failed
+		}
+	}
+
+	// 9. Store Buffer Info
+	vk_buffer_internal := new(Vk_Buffer_Internal, allocator)
+	vk_buffer_internal.buffer = buffer_handle
+	vk_buffer_internal.memory = device_memory
+	vk_buffer_internal.device_ref = vk_dev_internal
+	vk_buffer_internal.size = buffer_create_info.size // Store actual allocated size (could be mem_reqs.size)
+	vk_buffer_internal.allocator = allocator
+	vk_buffer_internal.mapped_ptr = nil // Not persistently mapped by default
+
+	log.infof("Vulkan buffer created and initialized: Gfx_Buffer wrapping Vk_Buffer_Internal %p (Buffer: %p, Memory: %p, Size: %v)",
+		vk_buffer_internal, buffer_handle, device_memory, vk_buffer_internal.size)
+	
+	return gfx_interface.Gfx_Buffer{variant = vk_buffer_internal}, .None
+}
+
+// vk_destroy_buffer_internal destroys a Vulkan buffer and frees its memory.
+vk_destroy_buffer_internal :: proc(buffer_handle_gfx: gfx_interface.Gfx_Buffer) {
+	vk_buffer_ptr, ok_buf := buffer_handle_gfx.variant.(^Vk_Buffer_Internal)
+	if !ok_buf || vk_buffer_ptr == nil {
+		log.errorf("vk_destroy_buffer: Invalid Gfx_Buffer type or nil variant (%v).", buffer_handle_gfx.variant)
+		return
+	}
+
+	buffer_internal := vk_buffer_ptr^ // Dereference to get the struct
+	logical_device := buffer_internal.device_ref.logical_device
+	p_vk_allocator: ^vk.AllocationCallbacks = nil
+
+	// Ensure buffer is unmapped if it was persistently mapped (not current design, but good practice)
+	if buffer_internal.mapped_ptr != nil {
+		log.warnf("Buffer %p was still mapped during destruction. Unmapping now.", buffer_internal.buffer)
+		vk.UnmapMemory(logical_device, buffer_internal.memory)
+		// vk_buffer_ptr.mapped_ptr = nil // Not strictly needed as we are freeing vk_buffer_ptr
+	}
+
+	if buffer_internal.buffer != vk.NULL_HANDLE {
+		log.debugf("Destroying Vulkan Buffer: %p", buffer_internal.buffer)
+		vk.DestroyBuffer(logical_device, buffer_internal.buffer, p_vk_allocator)
+	}
+	if buffer_internal.memory != vk.NULL_HANDLE {
+		log.debugf("Freeing Vulkan DeviceMemory: %p", buffer_internal.memory)
+		vk.FreeMemory(logical_device, buffer_internal.memory, p_vk_allocator)
+	}
+	
+	log.infof("Vk_Buffer_Internal %p destroyed (Buffer: %p, Memory: %p)", 
+		vk_buffer_ptr, buffer_internal.buffer, buffer_internal.memory)
+	
+	// Free the Vk_Buffer_Internal struct itself
+	free(vk_buffer_ptr, buffer_internal.allocator)
+}
+
+// vk_map_buffer_internal maps a Vulkan buffer's memory for CPU access.
+vk_map_buffer_internal :: proc(
+	buffer_handle_gfx: gfx_interface.Gfx_Buffer,
+	offset_bytes: int, // Renamed from offset
+	size_bytes: int,   // Renamed from size
+) -> rawptr {
+	vk_buffer_ptr, ok_buf := buffer_handle_gfx.variant.(^Vk_Buffer_Internal)
+	if !ok_buf || vk_buffer_ptr == nil {
+		log.errorf("vk_map_buffer: Invalid Gfx_Buffer type or nil variant (%v).", buffer_handle_gfx.variant)
+		return nil
+	}
+	buffer_internal := vk_buffer_ptr^
+	logical_device := buffer_internal.device_ref.logical_device
+
+	if buffer_internal.mapped_ptr != nil {
+		// This implies either persistent mapping (which we aren't fully set up for managing access)
+		// or a previous map call without a corresponding unmap.
+		log.warnf("Buffer %p is already mapped (or was mapped without unmap). Returning existing mapped pointer + offset.", buffer_internal.buffer)
+		return (^u8)(buffer_internal.mapped_ptr) + offset_bytes
+	}
+	
+	// Validate offset and size against buffer_internal.size
+	if offset_bytes < 0 || vk.DeviceSize(offset_bytes) >= buffer_internal.size {
+		log.errorf("vk_map_buffer: Invalid offset %d for buffer of size %v.", offset_bytes, buffer_internal.size)
+		return nil
+	}
+	map_size := vk.DeviceSize(size_bytes)
+	if size_bytes == -1 { // Convention for mapping whole buffer (or from offset to end)
+		map_size = buffer_internal.size - vk.DeviceSize(offset_bytes)
+	}
+	if vk.DeviceSize(offset_bytes) + map_size > buffer_internal.size {
+		log.warnf("vk_map_buffer: Requested map size (%d bytes from offset %d) exceeds buffer size (%v bytes). Clamping size.", 
+			size_bytes, offset_bytes, buffer_internal.size)
+		map_size = buffer_internal.size - vk.DeviceSize(offset_bytes)
+	}
+	if map_size == 0 {
+		log.warn("vk_map_buffer: Calculated map size is 0.")
+		return nil
+	}
+
+	log.debugf("Mapping buffer %p (Memory: %p), Offset: %d, Size: %v", 
+		buffer_internal.buffer, buffer_internal.memory, offset_bytes, map_size)
+	
+	mapped_data_ptr: rawptr
+	result := vk.MapMemory(logical_device, buffer_internal.memory, vk.DeviceSize(offset_bytes), map_size, 0, &mapped_data_ptr)
+	
+	if result == .SUCCESS && mapped_data_ptr != nil {
+		// Store the base mapped pointer if we were to support persistent mapping checks.
+		// For now, map/unmap are treated as paired calls by the user for a specific operation.
+		// vk_buffer_ptr.mapped_ptr = mapped_data_ptr; // If we wanted to track the base of this specific map.
+		// However, `Gfx_Buffer` interface implies map gives a pointer, unmap takes no pointer.
+		// So, the `mapped_ptr` in `Vk_Buffer_Internal` is more for if the buffer itself is "globally" mapped.
+		// Let's assume vkMapMemory/vkUnmapMemory are always paired by the user of Gfx_Buffer.
+		// We can store the most recent mapped pointer to ensure unmap is called on that.
+		vk_buffer_ptr.mapped_ptr = mapped_data_ptr // Store the pointer returned by THIS map call.
+		log.debugf("Buffer %p mapped successfully. Pointer: %p", buffer_internal.buffer, mapped_data_ptr)
+		return mapped_data_ptr
+	} else {
+		log.errorf("vkMapMemory failed for buffer %p. Result: %v", buffer_internal.buffer, result)
+		return nil
+	}
+}
+
+// vk_unmap_buffer_internal unmaps a previously mapped Vulkan buffer.
+vk_unmap_buffer_internal :: proc(buffer_handle_gfx: gfx_interface.Gfx_Buffer) {
+	vk_buffer_ptr, ok_buf := buffer_handle_gfx.variant.(^Vk_Buffer_Internal)
+	if !ok_buf || vk_buffer_ptr == nil {
+		log.errorf("vk_unmap_buffer: Invalid Gfx_Buffer type or nil variant (%v).", buffer_handle_gfx.variant)
+		return
+	}
+	buffer_internal := vk_buffer_ptr^
+	logical_device := buffer_internal.device_ref.logical_device
+
+	// HOST_COHERENT memory doesn't strictly need flushing before unmap,
+	// but if it weren't coherent, vkFlushMappedMemoryRanges would be needed here before unmap.
+	// vk.UnmapMemory itself makes host writes visible to device.
+
+	if buffer_internal.mapped_ptr == nil && vk_buffer_ptr.mapped_ptr == nil { // Check both, struct might have been copied
+		log.warnf("vk_unmap_buffer called on buffer %p that was not mapped (or already unmapped).", buffer_internal.buffer)
+		return
+	}
+	
+	log.debugf("Unmapping buffer %p (Memory: %p)", buffer_internal.buffer, buffer_internal.memory)
+	vk.UnmapMemory(logical_device, buffer_internal.memory)
+	vk_buffer_ptr.mapped_ptr = nil // Clear the stored mapped pointer
+	log.debug("Buffer unmapped successfully.")
+}

--- a/odingame/graphics/vulkan/vk_command.odin
+++ b/odingame/graphics/vulkan/vk_command.odin
@@ -1,0 +1,384 @@
+package vulkan
+
+import vk "vendor:vulkan"
+import "core:log"
+import "core:mem"
+import "../gfx_interface" 
+// For Vk_Window_Internal, Vk_Device_Internal, Vk_Pipeline_Internal, Vk_Buffer_Internal
+// we assume they are accessible if this file is part of the 'vulkan' package.
+
+// vk_begin_frame_internal starts a new frame for rendering.
+// - Waits for the previous frame (using fence).
+// - Acquires a new swapchain image.
+// - Resets and begins the command buffer for the current frame in flight.
+// - Stores the active command buffer and acquired image index in Vk_Window_Internal.
+// Returns true if successful, false if swapchain needs recreation (suboptimal/out of date).
+vk_begin_frame_internal :: proc(
+	window_handle_gfx: gfx_interface.Gfx_Window,
+) -> (ok: bool, active_cmd_buf: vk.CommandBuffer, acquired_image_idx: u32) {
+
+	vk_win, ok_win := window_handle_gfx.variant.(Vk_Window_Variant)
+	if !ok_win || vk_win == nil {
+		log.error("vk_begin_frame: Invalid Gfx_Window.")
+		return false, nil, 0
+	}
+	vk_dev := vk_win.device_ref
+	logical_device := vk_dev.logical_device
+	current_frame_idx_u64 := u64(vk_win.current_frame_index) // For indexing arrays
+
+	// 1. Wait for the fence of the frame we are about to render.
+	// Timeout for waiting (1 second in nanoseconds).
+	// Using vk.UINT64_MAX makes it wait indefinitely.
+	timeout_ns: u64 = 1_000_000_000 
+	wait_res := vk.WaitForFences(logical_device, 1, &vk_win.in_flight_fences[current_frame_idx_u64], vk.TRUE, timeout_ns)
+	if wait_res != .SUCCESS {
+		// This could be .TIMEOUT or an error.
+		log.errorf("vkWaitForFences timed out or failed for frame %d. Result: %v", vk_win.current_frame_index, wait_res)
+		// Depending on the error, might need to handle differently. For now, treat as critical.
+		return false, nil, 0 
+	}
+	// No need to vk.ResetFences if reset happens at QueueSubmit (which it doesn't, it's signaled by QueueSubmit)
+	// Fences are reset manually after waiting.
+	vk.ResetFences(logical_device, 1, &vk_win.in_flight_fences[current_frame_idx_u64])
+	log.debugf("Frame %d: In-flight fence waited and reset.", vk_win.current_frame_index)
+
+
+	// 2. Acquire next available swapchain image
+	var image_index_u32: u32
+	// Semaphores are signaled when operations complete. image_available_semaphore is signaled when presentation engine finishes reading from image.
+	acquire_res := vk.AcquireNextImageKHR(
+		logical_device,
+		vk_win.swapchain,
+		timeout_ns, // Or UINT64_MAX to wait indefinitely
+		vk_win.image_available_semaphores[current_frame_idx_u64], // Semaphore to signal when image is available
+		vk.NULL_HANDLE, // Fence to signal (optional, using in_flight_fences for command buffer submission)
+		&image_index_u32,
+	)
+
+	if acquire_res == .ERROR_OUT_OF_DATE_KHR {
+		log.warn("vkAcquireNextImageKHR: Swapchain is out of date. Needs recreation.")
+		vk_win.recreating_swapchain = true
+		return false, nil, 0 // Indicate swapchain needs recreation
+	} else if acquire_res == .SUBOPTIMAL_KHR {
+		log.warn("vkAcquireNextImageKHR: Swapchain is suboptimal. Needs recreation (but can still present).")
+		// Proceed with rendering for this frame, but flag for recreation.
+		vk_win.recreating_swapchain = true 
+	} else if acquire_res != .SUCCESS {
+		log.errorf("vkAcquireNextImageKHR failed. Result: %v", acquire_res)
+		return false, nil, 0 // Critical error
+	}
+	log.debugf("Frame %d: Acquired swapchain image %d.", vk_win.current_frame_index, image_index_u32)
+	
+	// Store acquired image index
+	vk_win.acquired_image_index = image_index_u32
+
+	// Check if a previous frame is using this image (i.e. there is its fence to wait on)
+	if vk_win.images_in_flight[image_index_u32] != vk.NULL_HANDLE {
+		fence_wait_res := vk.WaitForFences(logical_device, 1, &vk_win.images_in_flight[image_index_u32], vk.TRUE, timeout_ns)
+        if fence_wait_res != .SUCCESS {
+            log.errorf("vkWaitForFences for images_in_flight[%d] failed. Result: %v", image_index_u32, fence_wait_res)
+            return false, nil, 0
+        }
+	}
+	// Mark this image as now in use by the current frame
+	vk_win.images_in_flight[image_index_u32] = vk_win.in_flight_fences[current_frame_idx_u64]
+
+
+	// 3. Get and Reset Command Buffer for the current frame in flight
+	active_cmd_buf := vk_win.command_buffers[current_frame_idx_u64]
+	// vk.ResetCommandBuffer: Resets a command buffer to the initial state.
+	// Flags can be .RELEASE_RESOURCES_BIT to free resources, but usually not needed for simple reset.
+	reset_cmd_res := vk.ResetCommandBuffer(active_cmd_buf, 0) 
+	if reset_cmd_res != .SUCCESS {
+		log.errorf("vkResetCommandBuffer failed for frame %d. Result: %v", vk_win.current_frame_index, reset_cmd_res)
+		return false, nil, 0
+	}
+	log.debugf("Frame %d: Command buffer %p reset.", vk_win.current_frame_index, active_cmd_buf)
+
+	// 4. Begin Command Buffer Recording
+	cmd_buf_begin_info := vk.CommandBufferBeginInfo{
+		sType = .COMMAND_BUFFER_BEGIN_INFO,
+		flags = {.ONE_TIME_SUBMIT_BIT}, // Optional: if command buffer is recorded and submitted only once.
+		                                // For frame rendering, it's recorded each frame.
+		// pInheritanceInfo = nil, // Only for secondary command buffers
+	}
+	begin_res := vk.BeginCommandBuffer(active_cmd_buf, &cmd_buf_begin_info)
+	if begin_res != .SUCCESS {
+		log.errorf("vkBeginCommandBuffer failed for frame %d. Result: %v", vk_win.current_frame_index, begin_res)
+		return false, nil, 0
+	}
+	log.debugf("Frame %d: Command buffer %p recording begun.", vk_win.current_frame_index, active_cmd_buf)
+
+	// Store the active command buffer in Vk_Window_Internal for other command functions to use
+	vk_win.active_command_buffer = active_cmd_buf
+	
+	return true, active_cmd_buf, image_index_u32
+}
+
+// vk_end_frame_internal ends the current frame:
+// - Ends render pass and command buffer recording.
+// - Submits the command buffer.
+// - Presents the swapchain image.
+// - Updates current_frame_index.
+// Returns true if successful, false if swapchain needs recreation.
+vk_end_frame_internal :: proc(window_handle_gfx: gfx_interface.Gfx_Window) -> bool {
+	vk_win, ok_win := window_handle_gfx.variant.(Vk_Window_Variant)
+	if !ok_win || vk_win == nil {
+		log.error("vk_end_frame: Invalid Gfx_Window.")
+		return false
+	}
+	if vk_win.active_command_buffer == vk.NULL_HANDLE {
+		log.error("vk_end_frame: No active command buffer to end.")
+		// This might happen if begin_frame failed or wasn't called.
+		return false 
+	}
+	
+	vk_dev := vk_win.device_ref
+	logical_device := vk_dev.logical_device
+	graphics_queue := vk_dev.graphics_queue
+	present_queue := vk_dev.present_queue
+	current_frame_idx_u64 := u64(vk_win.current_frame_index)
+
+	active_cmd_buf := vk_win.active_command_buffer
+	acquired_image_idx_u32 := vk_win.acquired_image_index
+
+	// 1. End Render Pass (if one was started and not ended by user)
+	// Assuming vk_clear_screen or other drawing commands started a render pass.
+	// The task description implies vk_clear_screen starts it.
+	// If vk.CmdEndRenderPass is called here, it means all drawing within the frame
+	// must happen before vk_end_frame.
+	// This is a common pattern.
+	vk.CmdEndRenderPass(active_cmd_buf)
+	log.debugf("Frame %d: Render pass ended for command buffer %p.", vk_win.current_frame_index, active_cmd_buf)
+
+	// 2. End Command Buffer Recording
+	end_cmd_res := vk.EndCommandBuffer(active_cmd_buf)
+	if end_cmd_res != .SUCCESS {
+		log.errorf("vkEndCommandBuffer failed for frame %d. Result: %v", vk_win.current_frame_index, end_cmd_res)
+		return false // This is a critical error for the current frame.
+	}
+	log.debugf("Frame %d: Command buffer %p recording ended.", vk_win.current_frame_index, active_cmd_buf)
+
+	// 3. Submit Command Buffer
+	submit_info := vk.SubmitInfo{
+		sType = .SUBMIT_INFO,
+		waitSemaphoreCount = 1,
+		pWaitSemaphores = &vk_win.image_available_semaphores[current_frame_idx_u64],
+		// Pipeline stages to wait for: wait at color attachment output stage.
+		pWaitDstStageMask = &vk.PipelineStageFlags{.COLOR_ATTACHMENT_OUTPUT_BIT}, 
+		commandBufferCount = 1,
+		pCommandBuffers = &active_cmd_buf,
+		signalSemaphoreCount = 1,
+		pSignalSemaphores = &vk_win.render_finished_semaphores[current_frame_idx_u64],
+	}
+	
+	// Submit to graphics queue.
+	// The in_flight_fences[current_frame_index] will be signaled when this command buffer finishes execution.
+	// We already waited for this fence in begin_frame and reset it.
+	// No, the fence used here (in_flight_fences[current_frame_idx_u64]) is for this submission.
+	// images_in_flight[acquired_image_idx_u32] is also set to this same fence.
+	// This ensures that we don't try to render to an image that's still being rendered to from a previous submission
+	// that outputted to the same image index.
+	// The fence in_flight_fences[current_frame_idx_u64] ensures that we don't start recording commands for this frame_index
+	// if the *previous* use of this frame_index's command buffer and semaphores hasn't finished.
+	
+	// Ensure the fence is reset before use in vk.QueueSubmit
+	// vk.ResetFences(logical_device, 1, &vk_win.in_flight_fences[current_frame_idx_u64]) // Already done in begin_frame after wait.
+
+	submit_res := vk.QueueSubmit(graphics_queue, 1, &submit_info, vk_win.in_flight_fences[current_frame_idx_u64])
+	if submit_res != .SUCCESS {
+		log.errorf("vkQueueSubmit failed for frame %d. Result: %v", vk_win.current_frame_index, submit_res)
+		// This is critical. The fence might not be signaled.
+		return false
+	}
+	log.debugf("Frame %d: Command buffer submitted to graphics queue. Fence %p.", vk_win.current_frame_index, vk_win.in_flight_fences[current_frame_idx_u64])
+
+
+	// 4. Present Swapchain Image
+	present_info := vk.PresentInfoKHR{
+		sType = .PRESENT_INFO_KHR,
+		waitSemaphoreCount = 1,
+		pWaitSemaphores = &vk_win.render_finished_semaphores[current_frame_idx_u64], // Wait for rendering to finish
+		swapchainCount = 1,
+		pSwapchains = &vk_win.swapchain,
+		pImageIndices = &acquired_image_idx_u32,
+		// pResults = nil, // Optional: for checking results of multiple swapchains
+	}
+
+	present_res := vk.QueuePresentKHR(present_queue, &present_info)
+	
+	frame_recreation_needed := false
+	if present_res == .ERROR_OUT_OF_DATE_KHR || present_res == .SUBOPTIMAL_KHR {
+		log.warnf("vkQueuePresentKHR: Swapchain is out of date or suboptimal. Needs recreation. Result: %v", present_res)
+		vk_win.recreating_swapchain = true
+		frame_recreation_needed = true // Indicate to caller that swapchain needs attention
+	} else if present_res != .SUCCESS {
+		log.errorf("vkQueuePresentKHR failed. Result: %v", present_res)
+		// This is a critical error.
+		return false 
+	}
+	log.debugf("Frame %d: Image %d presented to queue.", vk_win.current_frame_index, acquired_image_idx_u32)
+
+	// 5. Update current_frame_index for next frame
+	vk_win.current_frame_index = (vk_win.current_frame_index + 1) % MAX_FRAMES_IN_FLIGHT
+	
+	// Clear active command buffer as it's now submitted
+	vk_win.active_command_buffer = vk.NULL_HANDLE 
+
+	return !frame_recreation_needed // Return true if successful, false if swapchain needs recreation.
+}
+
+
+// vk_clear_screen_internal begins a render pass and clears attachments.
+vk_clear_screen_internal :: proc(
+	// Assumes active_command_buffer and acquired_image_index are set in vk_win by begin_frame
+	window_handle_gfx: gfx_interface.Gfx_Window, 
+	options: gfx_interface.Clear_Options,
+) {
+	vk_win, ok_win := window_handle_gfx.variant.(Vk_Window_Variant)
+	if !ok_win || vk_win == nil { log.error("vk_clear_screen: Invalid Gfx_Window."); return }
+	
+	active_cmd_buf := vk_win.active_command_buffer
+	if active_cmd_buf == vk.NULL_HANDLE { log.error("vk_clear_screen: No active command buffer."); return }
+	
+	current_image_idx := vk_win.acquired_image_index
+	if current_image_idx >= u32(len(vk_win.framebuffers)) {
+		log.errorf("vk_clear_screen: acquired_image_index %d is out of bounds for framebuffers slice (len %d).",
+			current_image_idx, len(vk_win.framebuffers))
+		return
+	}
+	framebuffer := vk_win.framebuffers[current_image_idx]
+	
+	// Use the window's main render pass. Pipelines must be compatible with this.
+	render_pass_to_begin := vk_win.render_pass 
+	if render_pass_to_begin == vk.NULL_HANDLE {
+		log.error("vk_clear_screen: Window's render_pass is NULL.")
+		return
+	}
+
+	clear_value := vk.ClearValue{} // Union, default to all zeros
+	if options.clear_color {
+		// Vulkan expects color components in a specific order, usually RGBA.
+		clear_value.color.float32[0] = options.color[0]
+		clear_value.color.float32[1] = options.color[1]
+		clear_value.color.float32[2] = options.color[2]
+		clear_value.color.float32[3] = options.color[3]
+	}
+	// If depth/stencil were used, set clear_value.depthStencil here.
+	// Our current render pass has only one color attachment.
+
+	render_pass_begin_info := vk.RenderPassBeginInfo{
+		sType = .RENDER_PASS_BEGIN_INFO,
+		renderPass = render_pass_to_begin,
+		framebuffer = framebuffer,
+		renderArea = vk.Rect2D{
+			offset = {0, 0},
+			extent = vk_win.swapchain_extent,
+		},
+		clearValueCount = 1, // One clear value for the color attachment
+		pClearValues = &clear_value,
+	}
+
+	vk.CmdBeginRenderPass(active_cmd_buf, &render_pass_begin_info, .INLINE) // .INLINE for primary cmd bufs
+	log.debugf("Frame %d: Began render pass %p on framebuffer %p (image %d).", 
+		vk_win.current_frame_index, render_pass_to_begin, framebuffer, current_image_idx)
+}
+
+// vk_set_viewport_internal sets the dynamic viewport state.
+vk_set_viewport_internal :: proc(
+	active_cmd_buf: vk.CommandBuffer, 
+	viewport_data: gfx_interface.Viewport,
+) {
+	if active_cmd_buf == vk.NULL_HANDLE { log.error("vk_set_viewport: No active command buffer."); return }
+	
+	// Note: Vulkan's Y-axis for viewport is often top-down (positive Y down).
+	// If gfx_interface.Viewport assumes Y-up, conversion might be needed here or at projection matrix level.
+	// For now, direct mapping.
+	vk_viewport := vk.Viewport{
+		x = viewport_data.x,
+		y = viewport_data.y, // If Y needs flipping: window_height - viewport_data.y - viewport_data.height
+		width = viewport_data.width,
+		height = viewport_data.height,
+		minDepth = viewport_data.min_depth,
+		maxDepth = viewport_data.max_depth,
+	}
+	vk.CmdSetViewport(active_cmd_buf, 0, 1, &vk_viewport) // firstViewport=0, viewportCount=1
+}
+
+// vk_set_scissor_internal sets the dynamic scissor state.
+vk_set_scissor_internal :: proc(
+	active_cmd_buf: vk.CommandBuffer, 
+	scissor_data: gfx_interface.Scissor,
+) {
+	if active_cmd_buf == vk.NULL_HANDLE { log.error("vk_set_scissor: No active command buffer."); return }
+
+	vk_scissor := vk.Rect2D{
+		offset = {scissor_data.x, scissor_data.y},
+		extent = {u32(scissor_data.width), u32(scissor_data.height)},
+	}
+	vk.CmdSetScissor(active_cmd_buf, 0, 1, &vk_scissor) // firstScissor=0, scissorCount=1
+}
+
+// vk_set_pipeline_internal binds a graphics pipeline.
+vk_set_pipeline_internal :: proc(
+	window_handle_gfx: gfx_interface.Gfx_Window, // To store active layout/renderpass
+	pipeline_handle_gfx: gfx_interface.Gfx_Pipeline,
+) {
+	vk_win, ok_win := window_handle_gfx.variant.(Vk_Window_Variant)
+	if !ok_win || vk_win == nil { log.error("vk_set_pipeline: Invalid Gfx_Window."); return }
+	
+	vk_pipe, ok_pipe := pipeline_handle_gfx.variant.(^Vk_Pipeline_Internal)
+	if !ok_pipe || vk_pipe == nil { log.error("vk_set_pipeline: Invalid Gfx_Pipeline."); return }
+
+	active_cmd_buf := vk_win.active_command_buffer
+	if active_cmd_buf == vk.NULL_HANDLE { log.error("vk_set_pipeline: No active command buffer."); return }
+
+	vk.CmdBindPipeline(active_cmd_buf, .GRAPHICS, vk_pipe.pipeline)
+	log.debugf("Frame %d: Bound graphics pipeline %p.", vk_win.current_frame_index, vk_pipe.pipeline)
+
+	// Store layout and render pass for subsequent commands (e.g. bind descriptor sets, draw)
+	vk_win.active_pipeline_layout = vk_pipe.pipeline_layout
+	// vk_win.active_render_pass = vk_pipe.render_pass; // Render pass is started by clear_screen
+}
+
+// vk_set_vertex_buffer_internal binds a vertex buffer.
+vk_set_vertex_buffer_internal :: proc(
+	active_cmd_buf: vk.CommandBuffer,
+	buffer_handle_gfx: gfx_interface.Gfx_Buffer,
+	binding_index: u32, // The binding point
+	buffer_offset: u32, // Note: Gfx_Device_Interface uses 'offset', here using 'buffer_offset' to avoid conflict
+) {
+	if active_cmd_buf == vk.NULL_HANDLE { log.error("vk_set_vertex_buffer: No active command buffer."); return }
+
+	vk_buffer_internal, ok_buf := buffer_handle_gfx.variant.(^Vk_Buffer_Internal)
+	if !ok_buf || vk_buffer_internal == nil { log.error("vk_set_vertex_buffer: Invalid Gfx_Buffer."); return }
+
+	offsets := [1]vk.DeviceSize{vk.DeviceSize(buffer_offset)}
+	buffers_to_bind := [1]vk.Buffer{vk_buffer_internal.buffer}
+	
+	vk.CmdBindVertexBuffers(active_cmd_buf, binding_index, 1, &buffers_to_bind[0], &offsets[0])
+	log.debugf("Bound vertex buffer %p to binding %d with offset %d.", vk_buffer_internal.buffer, binding_index, buffer_offset)
+}
+
+
+// vk_draw_internal performs a non-indexed draw.
+vk_draw_internal :: proc(
+	active_cmd_buf: vk.CommandBuffer,
+	vertex_count: u32,
+	instance_count: u32,
+	first_vertex: u32,
+	first_instance: u32,
+) {
+	if active_cmd_buf == vk.NULL_HANDLE { log.error("vk_draw: No active command buffer."); return }
+	
+	vk.CmdDraw(active_cmd_buf, vertex_count, instance_count, first_vertex, first_instance)
+}
+
+// TODO: vk_draw_indexed_internal for indexed drawing.
+// vk_draw_indexed_internal :: proc(...) { vk.CmdDrawIndexed(...) }
+
+// TODO: vk_set_index_buffer_internal
+// vk_set_index_buffer_internal :: proc(...) { vk.CmdBindIndexBuffer(...) }
+
+// TODO: Uniform/Descriptor Set binding functions
+// These would use vk_win.active_pipeline_layout for vk.CmdBindDescriptorSets

--- a/odingame/graphics/vulkan/vk_device.odin
+++ b/odingame/graphics/vulkan/vk_device.odin
@@ -385,8 +385,25 @@ vk_create_logical_device_internal :: proc(
 	vk_device_internal := new(Vk_Device_Internal, allocator)
 	vk_device_internal.allocator = allocator
 	vk_device_internal.vk_instance = vk_instance_info
-	vk_device_internal.physical_device_info = physical_device_info // Store the selected physical device info
+	vk_device_internal.physical_device_info = physical_device_info
 	vk_device_internal.logical_device = logical_device_handle
+	vk_device_internal.primary_window_for_pipeline = nil // Initialized to nil
+	
+	// Create Command Pool
+	pool_create_info := vk.CommandPoolCreateInfo{
+		sType = .COMMAND_POOL_CREATE_INFO,
+		flags = {.RESET_COMMAND_BUFFER_BIT}, // Allow command buffers to be individually reset
+		queueFamilyIndex = indices.graphics_family.?, // Commands for graphics queue
+	}
+	cp_res := vk.CreateCommandPool(logical_device_handle, &pool_create_info, p_vk_allocator, &vk_device_internal.command_pool)
+	if cp_res != .SUCCESS {
+		log.errorf("vkCreateCommandPool failed. Result: %v", cp_res)
+		// Cleanup already created logical device
+		vk.DestroyDevice(logical_device_handle, p_vk_allocator)
+		free(vk_device_internal, allocator)
+		return nil, .Device_Creation_Failed
+	}
+	log.infof("Vulkan Command Pool created successfully: %p", vk_device_internal.command_pool)
 
 	// Get queue handles
 	// The queue index within the family is 0 since we only requested one queue (queueCount=1) per family.
@@ -525,6 +542,12 @@ vk_destroy_device_wrapper :: proc(device: gfx_interface.Gfx_Device) {
 		if vk_dev.logical_device != nil {
 			vk.DeviceWaitIdle(vk_dev.logical_device)
 			log.info("Vulkan Logical Device finished waiting for idle.")
+		}
+
+		// Destroy Command Pool (must be done before logical device)
+		if vk_dev.command_pool != vk.NULL_HANDLE && vk_dev.logical_device != nil {
+			log.infof("Destroying Vulkan Command Pool: %p", vk_dev.command_pool)
+			vk.DestroyCommandPool(vk_dev.logical_device, vk_dev.command_pool, nil) // pAllocator is nil
 		}
 
 		// Destroy logical device

--- a/odingame/graphics/vulkan/vk_pipeline.odin
+++ b/odingame/graphics/vulkan/vk_pipeline.odin
@@ -1,0 +1,349 @@
+package vulkan
+
+import vk "vendor:vulkan"
+import "core:log"
+import "core:mem"
+import "../gfx_interface" // For Gfx_Device, Gfx_Error, Gfx_Shader, Gfx_Pipeline, Shader_Stage
+// We need access to Vk_Shader_Internal from vk_shader.odin
+// Assuming vk_shader.odin is part of the same 'vulkan' package.
+
+// Vk_Pipeline_Internal holds the Vulkan-specific pipeline data.
+Vk_Pipeline_Internal :: struct {
+	pipeline:        vk.Pipeline,
+	pipeline_layout: vk.PipelineLayout,
+	render_pass:     vk.RenderPass,          // RenderPass used for this pipeline
+	device_ref:      ^Vk_Device_Internal,    // Reference to the logical device for destruction
+	allocator:       mem.Allocator,        // Allocator used for this struct
+}
+
+// vk_create_render_pass_internal creates a simple Vulkan RenderPass.
+// This function is now intended to be called by window/swapchain setup
+// to create a render pass compatible with the swapchain.
+// Pipelines will then be created to be compatible with this render pass.
+vk_create_render_pass_internal :: proc(
+	logical_device: vk.Device,
+	swapchain_format: vk.Format, 
+) -> (vk.RenderPass, gfx_interface.Gfx_Error) {
+	// allocator parameter removed as it's not creating heap-allocated Odin structs directly
+
+	color_attachment_desc := vk.AttachmentDescription{
+		format = swapchain_format,
+		samples = .SAMPLE_COUNT_1_BIT, // No multisampling for now
+		loadOp = .CLEAR,              // Clear framebuffer before rendering
+		storeOp = .STORE,             // Store rendered contents in memory
+		stencilLoadOp = .DONT_CARE,   // No stencil buffer
+		stencilStoreOp = .DONT_CARE,  // No stencil buffer
+		initialLayout = .UNDEFINED,   // Layout before render pass begins
+		finalLayout = .PRESENT_SRC_KHR, // Layout to transition to after render pass (for presentation)
+	}
+
+	color_attachment_ref := vk.AttachmentReference{
+		attachment = 0, // Index of the attachment in pAttachments array (we have one)
+		layout = .COLOR_ATTACHMENT_OPTIMAL, // Layout during the subpass
+	}
+
+	// Define a single subpass that uses the color attachment
+	subpass_desc := vk.SubpassDescription{
+		pipelineBindPoint = .GRAPHICS,
+		colorAttachmentCount = 1,
+		pColorAttachments = &color_attachment_ref, // Pointer to array of color attachment references
+		// pDepthStencilAttachment, pResolveAttachments, pInputAttachments, preserveAttachmentCount can be nil/0
+	}
+	
+	// Subpass dependency (optional but good for layout transitions)
+	// This ensures that the render pass waits for the image to be available before writing to it,
+	// and that writing is finished before the image is transitioned to PRESENT_SRC_KHR.
+	dependency := vk.SubpassDependency{
+		srcSubpass = vk.SUBPASS_EXTERNAL, // Implicit subpass before render pass
+		dstSubpass = 0,                   // Our subpass (index 0)
+		srcStageMask = {.COLOR_ATTACHMENT_OUTPUT_BIT},
+		srcAccessMask = {}, // No access needs to be synchronized before this
+		dstStageMask = {.COLOR_ATTACHMENT_OUTPUT_BIT},
+		dstAccessMask = {.COLOR_ATTACHMENT_WRITE_BIT},
+		// No dependencyFlags
+	}
+
+
+	render_pass_create_info := vk.RenderPassCreateInfo{
+		sType = .RENDER_PASS_CREATE_INFO,
+		attachmentCount = 1,
+		pAttachments = &color_attachment_desc,
+		subpassCount = 1,
+		pSubpasses = &subpass_desc,
+		dependencyCount = 1, // One dependency for now
+		pDependencies = &dependency,
+	}
+
+	p_vk_allocator: ^vk.AllocationCallbacks = nil
+	render_pass: vk.RenderPass
+
+	result := vk.CreateRenderPass(logical_device, &render_pass_create_info, p_vk_allocator, &render_pass)
+	if result != .SUCCESS {
+		log.errorf("vkCreateRenderPass failed. Result: %v (%d)", result, int(result))
+		return vk.NULL_HANDLE, .Device_Creation_Failed // Or a more specific error
+	}
+
+	log.infof("Vulkan RenderPass created successfully: %p (for format %v)", render_pass, swapchain_format)
+	return render_pass, .None
+}
+
+
+// vk_create_pipeline_layout_internal creates a Vulkan PipelineLayout.
+// For now, it's empty (no descriptor sets, no push constants).
+vk_create_pipeline_layout_internal :: proc(
+	logical_device: vk.Device,
+	// allocator: mem.Allocator, // Not needed for local stack allocations
+) -> (vk.PipelineLayout, gfx_interface.Gfx_Error) {
+	
+	layout_create_info := vk.PipelineLayoutCreateInfo{
+		sType = .PIPELINE_LAYOUT_CREATE_INFO,
+		setLayoutCount = 0, // No descriptor set layouts yet
+		pSetLayouts = nil,
+		pushConstantRangeCount = 0, // No push constants yet
+		pPushConstantRanges = nil,
+	}
+
+	p_vk_allocator: ^vk.AllocationCallbacks = nil
+	pipeline_layout: vk.PipelineLayout
+
+	result := vk.CreatePipelineLayout(logical_device, &layout_create_info, p_vk_allocator, &pipeline_layout)
+	if result != .SUCCESS {
+		log.errorf("vkCreatePipelineLayout failed. Result: %v (%d)", result, int(result))
+		return vk.NULL_HANDLE, .Device_Creation_Failed // Or a more specific error
+	}
+	
+	log.infof("Vulkan PipelineLayout created successfully (empty): %p", pipeline_layout)
+	return pipeline_layout, .None
+}
+
+
+// vk_create_pipeline_internal creates the Vulkan graphics pipeline.
+vk_create_pipeline_internal :: proc(
+	gfx_device: gfx_interface.Gfx_Device,
+	shaders: []gfx_interface.Gfx_Shader,
+	render_pass_handle: vk.RenderPass,     // Passed from wrapper
+	pipeline_layout_handle: vk.PipelineLayout, // Passed from wrapper
+	// Vertex input state parameters, derived from the active VAO by the wrapper
+	vertex_bindings: []Vk_Vertex_Input_Binding_Description, 
+	vertex_attributes: []Vk_Vertex_Input_Attribute_Description,
+) -> (gfx_interface.Gfx_Pipeline, gfx_interface.Gfx_Error) {
+
+	vk_dev_internal, ok_dev := gfx_device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev_internal == nil {
+		log.error("vk_create_pipeline: Invalid Gfx_Device (not Vulkan or nil variant).")
+		return gfx_interface.Gfx_Pipeline{}, .Invalid_Handle
+	}
+	allocator := vk_dev_internal.allocator // Use device's allocator for Vk_Pipeline_Internal struct
+
+	if len(shaders) == 0 {
+		log.error("Cannot create pipeline: no shaders provided.")
+		return gfx_interface.Gfx_Pipeline{}, .Shader_Compilation_Failed // Or Invalid_Parameter
+	}
+	if render_pass_handle == vk.NULL_HANDLE {
+		log.error("Cannot create pipeline: invalid render_pass_handle provided.")
+		return gfx_interface.Gfx_Pipeline{}, .Invalid_Handle
+	}
+	if pipeline_layout_handle == vk.NULL_HANDLE {
+		log.error("Cannot create pipeline: invalid pipeline_layout_handle provided.")
+		return gfx_interface.Gfx_Pipeline{}, .Invalid_Handle
+	}
+
+
+	// 1. Shader Stages
+	// Convert []Gfx_Shader to []vk.PipelineShaderStageCreateInfo
+	// Use a temporary allocator for the slice of shader stage create infos.
+	shader_stage_create_infos := make([dynamic]vk.PipelineShaderStageCreateInfo, 0, len(shaders), context.temp_allocator)
+	defer delete(shader_stage_create_infos) // Frees the dynamic array's buffer
+
+	entry_point_name := "main" // Standard entry point name for GLSL shaders
+
+	for _, gfx_shader_handle in shaders {
+		vk_shader_ptr, ok_shader := gfx_shader_handle.variant.(^Vk_Shader_Internal)
+		if !ok_shader || vk_shader_ptr == nil {
+			log.errorf("Invalid shader handle provided to pipeline creation. Variant: %v", gfx_shader_handle.variant)
+			return gfx_interface.Gfx_Pipeline{}, .Invalid_Handle
+		}
+		shader_internal := vk_shader_ptr^
+
+		stage_create_info := vk.PipelineShaderStageCreateInfo{
+			sType = .PIPELINE_SHADER_STAGE_CREATE_INFO,
+			stage = shader_internal.stage,
+			module = shader_internal.module,
+			pName = entry_point_name, // Must be null-terminated string
+			// pSpecializationInfo can be nil if no specialization constants
+		}
+		append(&shader_stage_create_infos, stage_create_info)
+		log.debugf("Pipeline: Added shader module %p for stage %v", shader_internal.module, shader_internal.stage)
+	}
+
+	// 2. Vertex Input State
+	// Uses the binding and attribute descriptions passed in (from active VAO)
+	vertex_input_state_create_info := vk.PipelineVertexInputStateCreateInfo{
+		sType = .PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
+		vertexBindingDescriptionCount = u32(len(vertex_bindings)),
+		pVertexBindingDescriptions = rawptr(vertex_bindings.data) if len(vertex_bindings) > 0 else nil,
+		vertexAttributeDescriptionCount = u32(len(vertex_attributes)),
+		pVertexAttributeDescriptions = rawptr(vertex_attributes.data) if len(vertex_attributes) > 0 else nil,
+	}
+	if len(vertex_bindings) > 0 || len(vertex_attributes) > 0 {
+		log.debugf("Pipeline: Vertex Input State: Bindings: %d, Attributes: %d.", len(vertex_bindings), len(vertex_attributes))
+	} else {
+		log.debug("Pipeline: Vertex Input State: No bindings, no attributes (empty VAO or default).")
+	}
+
+	// 3. Input Assembly State
+	input_assembly_state_create_info := vk.PipelineInputAssemblyStateCreateInfo{
+		sType = .PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+		topology = .TRIANGLE_LIST,
+		primitiveRestartEnable = vk.FALSE,
+	}
+	log.debugf("Pipeline: Input Assembly State: Topology %v", input_assembly_state_create_info.topology)
+
+	// 4. Viewport State (Viewport and Scissor will be dynamic)
+	viewport_state_create_info := vk.PipelineViewportStateCreateInfo{
+		sType = .PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+		viewportCount = 1, // One viewport
+		pViewports = nil,  // Dynamic, so nil here
+		scissorCount = 1,  // One scissor
+		pScissors = nil,   // Dynamic, so nil here
+	}
+	log.debug("Pipeline: Viewport State: 1 viewport, 1 scissor (dynamic).")
+
+	// 5. Rasterization State
+	rasterization_state_create_info := vk.PipelineRasterizationStateCreateInfo{
+		sType = .PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
+		depthClampEnable = vk.FALSE,
+		rasterizerDiscardEnable = vk.FALSE, // FALSE means geometry passes to fragment shader
+		polygonMode = .FILL,
+		lineWidth = 1.0, // Required even if not drawing lines
+		cullMode = {.BACK_BIT}, // Cull back faces
+		frontFace = .COUNTER_CLOCKWISE, // Or .CLOCKWISE, depends on vertex winding order
+		depthBiasEnable = vk.FALSE,
+		// depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor = 0
+	}
+	log.debugf("Pipeline: Rasterization State: PolygonMode %v, CullMode %v, FrontFace %v", 
+		rasterization_state_create_info.polygonMode, rasterization_state_create_info.cullMode, rasterization_state_create_info.frontFace)
+
+	// 6. Multisample State
+	multisample_state_create_info := vk.PipelineMultisampleStateCreateInfo{
+		sType = .PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+		sampleShadingEnable = vk.FALSE, // Disable sample shading
+		rasterizationSamples = .SAMPLE_COUNT_1_BIT, // No MSAA for now
+		// minSampleShading, pSampleMask, alphaToCoverageEnable, alphaToOneEnable can be default/0/nil
+	}
+	log.debugf("Pipeline: Multisample State: Samples %v", multisample_state_create_info.rasterizationSamples)
+
+	// 7. Depth/Stencil State (Not used for now, but a placeholder might be needed)
+	// For now, no depth/stencil test.
+	// depth_stencil_state_create_info := vk.PipelineDepthStencilStateCreateInfo{...}
+	// If not using depth/stencil, pDepthStencilState in VkGraphicsPipelineCreateInfo can be nil.
+	// However, if a render pass has a depth/stencil attachment, this must be configured.
+	// Our current render pass does not have one.
+	log.debug("Pipeline: Depth/Stencil State: Disabled (not configured).")
+
+
+	// 8. Color Blend State (One attachment, no blending)
+	color_blend_attachment_state := vk.PipelineColorBlendAttachmentState{
+		colorWriteMask = vk.ColorComponentFlags{.R_BIT, .G_BIT, .B_BIT, .A_BIT},
+		blendEnable = vk.FALSE, // No blending for now
+		// srcColorBlendFactor, dstColorBlendFactor, colorBlendOp, etc. are ignored if blendEnable is FALSE
+	}
+
+	color_blend_state_create_info := vk.PipelineColorBlendStateCreateInfo{
+		sType = .PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
+		logicOpEnable = vk.FALSE, // Logic op disabled
+		// logicOp = .COPY, // Optional if logicOpEnable is FALSE
+		attachmentCount = 1,
+		pAttachments = &color_blend_attachment_state, // Pointer to array of blend attachment states
+		// blendConstants[4] can be default
+	}
+	log.debug("Pipeline: Color Blend State: Blending disabled, 1 attachment.")
+
+	// 9. Dynamic State
+	dynamic_states_arr: [2]vk.DynamicState = {.VIEWPORT, .SCISSOR}
+	dynamic_state_create_info := vk.PipelineDynamicStateCreateInfo{
+		sType = .PIPELINE_DYNAMIC_STATE_CREATE_INFO,
+		dynamicStateCount = u32(len(dynamic_states_arr)),
+		pDynamicStates = &dynamic_states_arr[0],
+	}
+	log.debugf("Pipeline: Dynamic States: %v", dynamic_states_arr[:])
+
+	// 10. Graphics Pipeline Create Info
+	pipeline_create_info := vk.GraphicsPipelineCreateInfo{
+		sType = .GRAPHICS_PIPELINE_CREATE_INFO,
+		stageCount = u32(len(shader_stage_create_infos)),
+		pStages = shader_stage_create_infos.data,
+		pVertexInputState = &vertex_input_state_create_info,
+		pInputAssemblyState = &input_assembly_state_create_info,
+		// pTessellationState = nil, // No tessellation
+		pViewportState = &viewport_state_create_info,
+		pRasterizationState = &rasterization_state_create_info,
+		pMultisampleState = &multisample_state_create_info,
+		pDepthStencilState = nil, // No depth/stencil testing for now
+		pColorBlendState = &color_blend_state_create_info,
+		pDynamicState = &dynamic_state_create_info,
+		layout = pipeline_layout_handle, // Use the passed-in layout
+		renderPass = render_pass_handle, // Use the passed-in render pass
+		subpass = 0, // Index of the subpass where this pipeline will be used
+		// basePipelineHandle = vk.NULL_HANDLE, // Optional: for deriving from another pipeline
+		// basePipelineIndex = -1,             // Optional
+	}
+
+	// 11. Create Graphics Pipeline
+	p_vk_allocator: ^vk.AllocationCallbacks = nil
+	graphics_pipeline: vk.Pipeline
+
+	// vk.CreateGraphicsPipelines takes an array of create infos and returns an array of pipelines.
+	// We are creating a single pipeline.
+	result := vk.CreateGraphicsPipelines(vk_dev_internal.logical_device, vk.NULL_HANDLE, 1, &pipeline_create_info, p_vk_allocator, &graphics_pipeline)
+	if result != .SUCCESS {
+		log.errorf("vkCreateGraphicsPipelines failed. Result: %v (%d)", result, int(result))
+		// Note: If this fails, render_pass_handle and pipeline_layout_handle are owned by the caller (wrapper)
+		// and should be destroyed there if this function returns an error.
+		return gfx_interface.Gfx_Pipeline{}, .Device_Creation_Failed // Or more specific error
+	}
+	log.infof("Vulkan Graphics Pipeline created successfully: %p", graphics_pipeline)
+
+	// 12. Store pipeline and related info
+	vk_pipeline_internal := new(Vk_Pipeline_Internal, allocator)
+	vk_pipeline_internal.pipeline = graphics_pipeline
+	vk_pipeline_internal.pipeline_layout = pipeline_layout_handle // Store the passed-in layout
+	vk_pipeline_internal.render_pass = render_pass_handle       // Store the passed-in render pass
+	vk_pipeline_internal.device_ref = vk_dev_internal
+	vk_pipeline_internal.allocator = allocator
+
+	return gfx_interface.Gfx_Pipeline{variant = vk_pipeline_internal}, .None
+}
+
+
+// vk_destroy_pipeline_internal destroys the Vulkan pipeline and its layout.
+// vk_destroy_pipeline_internal destroys the Vulkan pipeline and its layout.
+// The RenderPass is now owned by the window/swapchain, so it's not destroyed here.
+vk_destroy_pipeline_internal :: proc(pipeline_handle: gfx_interface.Gfx_Pipeline) {
+	vk_pipe_ptr, ok_pipe := pipeline_handle.variant.(^Vk_Pipeline_Internal)
+	if !ok_pipe || vk_pipe_ptr == nil {
+		log.errorf("vk_destroy_pipeline: Invalid Gfx_Pipeline type or nil variant (%v).", pipeline_handle.variant)
+		return
+	}
+
+	vk_pipeline_internal := vk_pipe_ptr^ // Dereference to get the struct
+	logical_device := vk_pipeline_internal.device_ref.logical_device
+	p_vk_allocator: ^vk.AllocationCallbacks = nil
+
+	if vk_pipeline_internal.pipeline != vk.NULL_HANDLE {
+		log.infof("Destroying Vulkan Graphics Pipeline: %p", vk_pipeline_internal.pipeline)
+		vk.DestroyPipeline(logical_device, vk_pipeline_internal.pipeline, p_vk_allocator)
+	}
+	if vk_pipeline_internal.pipeline_layout != vk.NULL_HANDLE {
+		log.infof("Destroying Vulkan PipelineLayout: %p", vk_pipeline_internal.pipeline_layout)
+		vk.DestroyPipelineLayout(logical_device, vk_pipeline_internal.pipeline_layout, p_vk_allocator)
+	}
+	// RenderPass (vk_pipeline_internal.render_pass) is not destroyed here as it's assumed to be owned by the window.
+	// If it were a pipeline-specific render pass, it would be destroyed here.
+	log.debugf("RenderPass %p associated with pipeline %p was not destroyed by pipeline (owned by window/swapchain).",
+		vk_pipeline_internal.render_pass, vk_pipeline_internal.pipeline)
+	
+	// Free the Vk_Pipeline_Internal struct itself
+	free(vk_pipe_ptr, vk_pipeline_internal.allocator)
+	log.info("Vk_Pipeline_Internal struct freed.")
+}

--- a/odingame/graphics/vulkan/vk_shader.odin
+++ b/odingame/graphics/vulkan/vk_shader.odin
@@ -1,0 +1,276 @@
+package vulkan
+
+import vk "vendor:vulkan"
+import "core:log"
+import "core:mem"
+import "../gfx_interface" // For Gfx_Device, Gfx_Error, Gfx_Shader, Shader_Stage
+
+// Vk_Shader_Internal holds the Vulkan-specific shader data.
+Vk_Shader_Internal :: struct {
+	module:        vk.ShaderModule,
+	stage:         vk.ShaderStageFlagBits, // Store the stage for pipeline creation
+	device_ref:    ^Vk_Device_Internal,    // Reference to the logical device for destruction
+	allocator:     mem.Allocator,        // Allocator used for this struct
+}
+
+// Helper to map gfx_interface.Shader_Stage to vk.ShaderStageFlagBits
+map_shader_stage_to_vk :: proc(stage: gfx_interface.Shader_Stage) -> (vk.ShaderStageFlagBits, bool) {
+	#partial switch stage {
+	case .Vertex:
+		return .VERTEX_BIT, true
+	case .Fragment:
+		return .FRAGMENT_BIT, true
+	case .Compute:
+		return .COMPUTE_BIT, true
+	// TODO: Add other stages like Geometry, Tessellation if needed
+	}
+	log.errorf("Unsupported shader stage: %v", stage)
+	return vk.ShaderStageFlagBits(0), false // Invalid stage
+}
+
+// vk_create_shader_module creates a Vulkan shader module from SPIR-V bytecode.
+// Assumes bytecode is valid SPIR-V.
+vk_create_shader_module_internal :: proc(logical_device: vk.Device, bytecode: []u8) -> (vk.ShaderModule, gfx_interface.Gfx_Error) {
+	if len(bytecode) == 0 {
+		log.error("Shader bytecode is empty.")
+		return vk.NULL_HANDLE, .Shader_Compilation_Failed // Or a more specific error
+	}
+	if len(bytecode) % 4 != 0 {
+		log.error("Shader bytecode size is not a multiple of 4.")
+		return vk.NULL_HANDLE, .Shader_Compilation_Failed
+	}
+
+	create_info := vk.ShaderModuleCreateInfo{
+		sType = .SHADER_MODULE_CREATE_INFO,
+		codeSize = uintptr(len(bytecode)),
+		// pCode needs to point to an array of u32, so bytecode (slice of u8) needs careful casting.
+		// The bytecode is assumed to be correctly aligned for u32 access.
+		pCode = (^u32)(rawptr(bytecode.data)),
+	}
+
+	p_vk_allocator: ^vk.AllocationCallbacks = nil // Using nil for Vulkan allocation callbacks
+	shader_module: vk.ShaderModule
+
+	result := vk.CreateShaderModule(logical_device, &create_info, p_vk_allocator, &shader_module)
+	if result != .SUCCESS {
+		log.errorf("vkCreateShaderModule failed. Result: %v (%d)", result, int(result))
+		// Log more details if possible, e.g., from validation layers if they provide info
+		return vk.NULL_HANDLE, .Shader_Compilation_Failed
+	}
+
+	log.infof("Vulkan Shader Module created successfully: %p", shader_module)
+	return shader_module, .None
+}
+
+// vk_create_shader_from_bytecode creates a Gfx_Shader from SPIR-V bytecode.
+vk_create_shader_from_bytecode_internal :: proc(
+	gfx_device: gfx_interface.Gfx_Device,
+	bytecode: []u8,
+	stage: gfx_interface.Shader_Stage,
+) -> (gfx_interface.Gfx_Shader, gfx_interface.Gfx_Error) {
+	
+	vk_dev_internal, ok_dev := gfx_device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev_internal == nil {
+		log.error("vk_create_shader_from_bytecode: Invalid Gfx_Device (not Vulkan or nil variant).")
+		return gfx_interface.Gfx_Shader{}, .Invalid_Handle
+	}
+
+	allocator := vk_dev_internal.allocator // Use device's allocator
+
+	vk_stage, ok_stage := map_shader_stage_to_vk(stage)
+	if !ok_stage {
+		return gfx_interface.Gfx_Shader{}, .Shader_Compilation_Failed // Or a more specific error like .Invalid_Stage
+	}
+
+	shader_module, err := vk_create_shader_module_internal(vk_dev_internal.logical_device, bytecode)
+	if err != .None {
+		return gfx_interface.Gfx_Shader{}, err
+	}
+
+	// Allocate and populate Vk_Shader_Internal
+	vk_shader_internal := new(Vk_Shader_Internal, allocator)
+	vk_shader_internal.module = shader_module
+	vk_shader_internal.stage = vk_stage
+	vk_shader_internal.device_ref = vk_dev_internal
+	vk_shader_internal.allocator = allocator
+	
+	log.infof("Vk_Shader_Internal created for stage %v, module %p", stage, shader_module)
+
+	// Wrap it in Gfx_Shader
+	// The Gfx_Shader struct_variant will store a pointer to Vk_Shader_Internal.
+	// This requires Gfx_Shader in gfx_interface.odin to have a `vulkan: ^Vk_Shader_Internal` field.
+	// We used a placeholder `vulkan: ^struct{}` before. Now we need to make sure it's compatible.
+	// For now, this direct assignment will work if the placeholder is ^rawptr or similar.
+	// It's better to update gfx_interface.odin properly.
+	
+	return gfx_interface.Gfx_Shader{variant = vk_shader_internal}, .None
+}
+
+// vk_destroy_shader_internal destroys a Vulkan shader module.
+vk_destroy_shader_internal :: proc(shader: gfx_interface.Gfx_Shader) {
+	vk_shader_ptr, ok_shader := shader.variant.(^Vk_Shader_Internal)
+	if !ok_shader || vk_shader_ptr == nil {
+		log.errorf("vk_destroy_shader: Invalid Gfx_Shader type or nil variant (%v).", shader.variant)
+		return
+	}
+
+	vk_shader_internal := vk_shader_ptr^ // Dereference to get the struct
+
+	if vk_shader_internal.module != vk.NULL_HANDLE && vk_shader_internal.device_ref != nil {
+		log.infof("Destroying Vulkan Shader Module: %p (Stage: %v)", vk_shader_internal.module, vk_shader_internal.stage)
+		p_vk_allocator: ^vk.AllocationCallbacks = nil
+		vk.DestroyShaderModule(vk_shader_internal.device_ref.logical_device, vk_shader_internal.module, p_vk_allocator)
+	} else {
+		log.warnf("Attempted to destroy shader, but module is NULL or device_ref is nil. Module: %p", vk_shader_internal.module)
+	}
+	
+	// Free the Vk_Shader_Internal struct itself using its stored allocator
+	free(vk_shader_ptr, vk_shader_internal.allocator)
+	log.info("Vk_Shader_Internal struct freed.")
+}
+
+// vk_create_shader_from_source_internal (GLSL to SPIR-V using shaderc)
+vk_create_shader_from_source_internal :: proc(
+    gfx_device: gfx_interface.Gfx_Device,
+    glsl_source: string,
+    shader_stage_gfx: gfx_interface.Shader_Stage,
+) -> (gfx_interface.Gfx_Shader, gfx_interface.Gfx_Error) {
+
+	vk_dev_internal, ok_dev := gfx_device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev_internal == nil {
+		log.error("vk_create_shader_from_source: Invalid Gfx_Device.")
+		return gfx_interface.Gfx_Shader{}, .Invalid_Handle
+	}
+	allocator := vk_dev_internal.allocator
+
+	// 1. Initialize Shaderc Compiler and Options
+	compiler := shaderc.compiler_initialize()
+	if compiler == nil {
+		log.error("Failed to initialize shaderc compiler.")
+		return gfx_interface.Gfx_Shader{}, .Shader_Compilation_Failed
+	}
+	defer shaderc.compiler_release(compiler)
+
+	options := shaderc.compile_options_initialize()
+	if options == nil {
+		log.error("Failed to initialize shaderc compile options.")
+		return gfx_interface.Gfx_Shader{}, .Shader_Compilation_Failed
+	}
+	defer shaderc.compile_options_release(options)
+
+	// Set source language to GLSL
+	shaderc.compile_options_set_source_language(options, .GLSL)
+	// Optionally, set optimization level, e.g., for performance
+	// shaderc.compile_options_set_optimization_level(options, .Performance)
+    // For debugging, generate debug info
+    shaderc.compile_options_set_generate_debug_info(options)
+
+
+	// 2. Map gfx_interface.Shader_Stage to shaderc.Shader_Kind
+	shader_kind_sc, ok_kind := map_gfx_stage_to_shaderc_kind(shader_stage_gfx)
+	if !ok_kind {
+		log.errorf("Unsupported shader stage for shaderc compilation: %v", shader_stage_gfx)
+		return gfx_interface.Gfx_Shader{}, .Shader_Compilation_Failed
+	}
+
+	// 3. Compile GLSL to SPIR-V
+	// Convert Odin string to C-string for shaderc
+	source_cstring := strings.clone_to_cstring(glsl_source, context.temp_allocator) // Use temp allocator
+	defer delete(source_cstring, context.temp_allocator)
+	
+	// Define input file name (can be a placeholder) and entry point
+	// Shaderc uses these for error messages and some shader conventions.
+	// TODO: make input_file_name more meaningful if possible, e.g. from a loaded file path
+	input_file_name_cstr := "shader.glsl" 
+	entry_point_name_cstr := "main" // Standard entry point for GLSL shaders
+
+	log.infof("Compiling GLSL shader (stage: %v, input_name: %s, entry_point: %s) using shaderc...", 
+		shader_stage_gfx, input_file_name_cstr, entry_point_name_cstr)
+
+	result := shaderc.compile_into_spv(
+		compiler,
+		source_cstring,
+		size_t(len(glsl_source)), // shaderc expects length of original string, not necessarily null-terminated cstring length
+		shader_kind_sc,
+		input_file_name_cstr,
+		entry_point_name_cstr,
+		options,
+	)
+	defer shaderc.result_release(result)
+
+	// 4. Check Compilation Status
+	status := shaderc.result_get_compilation_status(result)
+	num_errors := shaderc.result_get_num_errors(result)
+	num_warnings := shaderc.result_get_num_warnings(result)
+
+	if num_warnings > 0 {
+		log.warnf("Shaderc compilation generated %d warnings:", num_warnings)
+		warning_msg_cstr := shaderc.result_get_error_message(result) // Errors and warnings are often in the same message buffer
+		if warning_msg_cstr != nil {
+			log.warn(string(warning_msg_cstr)) // Convert cstring to Odin string for logging
+		}
+	}
+
+	if status != .Success || num_errors > 0 {
+		log.errorf("Shaderc compilation failed with status %v and %d errors:", status, num_errors)
+		error_msg_cstr := shaderc.result_get_error_message(result)
+		if error_msg_cstr != nil {
+			log.error(string(error_msg_cstr))
+		}
+		return gfx_interface.Gfx_Shader{}, .Shader_Compilation_Failed
+	}
+
+	log.info("Shaderc compilation successful.")
+
+	// 5. Extract SPIR-V Bytecode
+	bytecode_len := shaderc.result_get_length(result)
+	bytecode_ptr := shaderc.result_get_bytes(result) // rawptr to const char* (effectively const u8*)
+
+	if bytecode_ptr == nil || bytecode_len == 0 {
+		log.error("Shaderc compilation succeeded but returned no bytecode.")
+		return gfx_interface.Gfx_Shader{}, .Shader_Compilation_Failed
+	}
+
+	// Create an Odin slice from the raw SPIR-V bytecode.
+	// This requires copying the data, as the memory from shaderc_result_get_bytes
+	// is only valid until shaderc_result_release is called.
+	spirv_bytecode_slice := make([]u8, int(bytecode_len), allocator) // Use device's allocator
+	mem.copy(spirv_bytecode_slice, (^u8)(bytecode_ptr), int(bytecode_len))
+	// Defer deletion if we don't pass ownership to vk_create_shader_from_bytecode_internal,
+	// but that function will use it to create a module, so the copy is good.
+
+	log.infof("Successfully compiled GLSL to SPIR-V bytecode (size: %d bytes).", bytecode_len)
+
+	// 6. Call vk_create_shader_from_bytecode_internal with the new bytecode
+	// The `spirv_bytecode_slice` is now owned by this scope, but will be consumed by the next call.
+	// If `vk_create_shader_from_bytecode_internal` makes its own copy or the shader module creation consumes it,
+	// then we might need to `defer delete(spirv_bytecode_slice)` if that call fails.
+	// However, our `vk_create_shader_module_internal` uses the slice directly without copying it again.
+	// The `Vk_Shader_Internal` doesn't store the bytecode slice itself, only the module.
+	// So, the `spirv_bytecode_slice` can be temporary for the call to `vk_create_shader_module_internal`.
+	// Let's use a temporary allocator for it for clarity, or ensure its lifetime is managed.
+	// For simplicity, if `vk_create_shader_from_bytecode_internal` doesn't take ownership of the slice memory,
+	// we should use a temporary allocation for `spirv_bytecode_slice` or ensure it's deleted.
+	// The current `vk_create_shader_from_bytecode_internal` does not store the slice.
+	// `vk_create_shader_module_internal` uses it.
+	// Let's make a copy that will be passed and can be freed after module creation if needed.
+	// For now, assume `vk_create_shader_from_bytecode_internal` handles it.
+	// The current approach with `allocator` for `spirv_bytecode_slice` means it's heap-allocated.
+	// If the call to `vk_create_shader_from_bytecode_internal` is successful, the data has been used.
+	// If it fails, the slice should be deleted.
+	
+	gfx_shader, creation_err := vk_create_shader_from_bytecode_internal(gfx_device, spirv_bytecode_slice, shader_stage_gfx)
+	if creation_err != .None {
+		delete(spirv_bytecode_slice) // Clean up our copy if module creation failed
+		log.errorf("Failed to create shader module from shaderc-compiled SPIR-V: %v", creation_err)
+		return gfx_interface.Gfx_Shader{}, creation_err
+	}
+	
+	// If successful, the bytecode has been consumed by vkCreateShaderModule.
+	// The slice `spirv_bytecode_slice` can be deleted as its data is now part of the Vulkan module.
+	// This is important if `allocator` is not a frame/temporary allocator.
+	delete(spirv_bytecode_slice) 
+	
+	log.info("Successfully created Gfx_Shader from GLSL source via shaderc.")
+	return gfx_shader, .None
+}

--- a/odingame/graphics/vulkan/vk_shaderc_foreign.odin
+++ b/odingame/graphics/vulkan/vk_shaderc_foreign.odin
@@ -1,0 +1,133 @@
+package vulkan
+
+// Odin foreign bindings for libshaderc
+// Based on shaderc/shaderc.h from Google's shaderc repository.
+
+foreign import shaderc "system:shaderc_shared" // Or "system:shaderc" - depends on how libshaderc-dev names the .so
+// If the above doesn't work, one might need to link explicitly via build flags, e.g. -L/path/to/libs -lshaderc_shared
+
+@(default_calling_convention="c")
+foreign shaderc {
+	// --- Enums ---
+	Source_Language :: enum i32 {
+		GLSL,
+		HLSL,
+	}
+
+	// Maps to gfx_interface.Shader_Stage and then to vk.ShaderStageFlagBits
+	// This enum is for shaderc's understanding of the input.
+	Shader_Kind :: enum i32 {
+		Vertex_Shader,
+		Fragment_Shader,
+		Compute_Shader,
+		Geometry_Shader,
+		Tess_Control_Shader,
+		Tess_Evaluation_Shader,
+
+		GLSL_Vertex_Shader                  = Vertex_Shader,
+		GLSL_Fragment_Shader                = Fragment_Shader,
+		GLSL_Compute_Shader                 = Compute_Shader,
+		GLSL_Geometry_Shader                = Geometry_Shader,
+		GLSL_Tess_Control_Shader            = Tess_Control_Shader,
+		GLSL_Tess_Evaluation_Shader         = Tess_Evaluation_Shader,
+
+		GLSL_Infer_From_Source,
+		GLSL_Default_Vertex_Shader,
+		GLSL_Default_Fragment_Shader,
+		GLSL_Default_Compute_Shader,
+		GLSL_Default_Geometry_Shader,
+		GLSL_Default_Tess_Control_Shader,
+		GLSL_Default_Tess_Evaluation_Shader,
+		SPIRV_Assembly,
+		RayGen_Shader,
+		AnyHit_Shader,
+		ClosestHit_Shader,
+		Miss_Shader,
+		Intersection_Shader,
+		Callable_Shader,
+		// ... and more GLSL specific defaults for raytracing ...
+		Task_Shader,
+		Mesh_Shader,
+	}
+
+	Compilation_Status :: enum i32 {
+		Success                          = 0,
+		Invalid_Stage                    = 1, // error stage deduction
+		Compilation_Error                = 2, // errors found during compilation
+		Internal_Error                   = 3, // unexpected failure
+		Null_Result_Object               = 4,
+		Invalid_Assembly                 = 5,
+		Validation_Error                 = 6, // TODO: Check exact name for this in newer shaderc.h if different
+		Transformation_Error             = 7,
+		Configuration_Error              = 8,
+	}
+
+	Optimization_Level :: enum i32 {
+		Zero,        // no optimization
+		Size,        // optimize towards reducing code size
+		Performance, // optimize towards performance
+	}
+
+	// --- Opaque Structs (Handles) ---
+	Compiler :: distinct rawptr // shaderc_compiler_t
+	Compile_Options :: distinct rawptr // shaderc_compile_options_t
+	Compilation_Result :: distinct rawptr // shaderc_compilation_result_t
+
+	// --- Functions ---
+	compiler_initialize :: proc() -> Compiler ---
+	compiler_release :: proc(compiler: Compiler) ---
+
+	compile_options_initialize :: proc() -> Compile_Options ---
+	compile_options_release :: proc(options: Compile_Options) ---
+	// compile_options_clone :: proc(options: Compile_Options) -> Compile_Options --- // Optional
+
+	compile_options_add_macro_definition :: proc(
+		options: Compile_Options,
+		name: cstring, name_length: size_t,
+		value: cstring, value_length: size_t,
+	) ---
+	compile_options_set_source_language :: proc(options: Compile_Options, lang: Source_Language) ---
+	compile_options_set_generate_debug_info :: proc(options: Compile_Options) ---
+	compile_options_set_optimization_level :: proc(options: Compile_Options, level: Optimization_Level) ---
+	// compile_options_set_forced_version_profile :: proc(options: Compile_Options, version: i32, profile: Profile) --- // Profile enum needed
+	// compile_options_set_include_callbacks :: proc(...) --- // For #include handling, complex
+	compile_options_set_suppress_warnings :: proc(options: Compile_Options) ---
+	// compile_options_set_target_env :: proc(options: Compile_Options, target: Target_Env, version: u32) --- // Target_Env, Env_Version enums needed
+	// compile_options_set_target_spirv :: proc(options: Compile_Options, version: SPIRV_Version) --- // SPIRV_Version enum needed
+	compile_options_set_warnings_as_errors :: proc(options: Compile_Options) ---
+	// ... many other options functions ...
+
+	compile_into_spv :: proc(
+		compiler: Compiler,
+		source_text: cstring,
+		source_text_size: size_t,
+		shader_kind: Shader_Kind,
+		input_file_name: cstring,
+		entry_point_name: cstring,
+		additional_options: Compile_Options,
+	) -> Compilation_Result ---
+	
+	// compile_into_spv_assembly :: proc(...) -> Compilation_Result ---
+	// compile_into_preprocessed_text :: proc(...) -> Compilation_Result ---
+	// assemble_into_spv :: proc(...) -> Compilation_Result ---
+
+	result_release :: proc(result: Compilation_Result) ---
+	result_get_length :: proc(result: Compilation_Result) -> size_t ---
+	result_get_num_warnings :: proc(result: Compilation_Result) -> size_t ---
+	result_get_num_errors :: proc(result: Compilation_Result) -> size_t ---
+	result_get_compilation_status :: proc(result: Compilation_Result) -> Compilation_Status ---
+	result_get_bytes :: proc(result: Compilation_Result) -> rawptr --- // ^u8 or ^u32 depending on context
+	result_get_error_message :: proc(result: Compilation_Result) -> cstring ---
+}
+
+// Helper to map gfx_interface.Shader_Stage to shaderc.Shader_Kind
+map_gfx_stage_to_shaderc_kind :: proc(stage: gfx_interface.Shader_Stage) -> (Shader_Kind, bool) {
+	#partial switch stage {
+		case .Vertex:   return .Vertex_Shader, true
+		case .Fragment: return .Fragment_Shader, true
+		case .Compute:  return .Compute_Shader, true
+		// case .Geometry: return .Geometry_Shader, true // If gfx_interface adds Geometry
+		// Add other mappings as gfx_interface.Shader_Stage expands
+	}
+	return Shader_Kind(-1), false // Invalid or unsupported stage
+}

--- a/odingame/graphics/vulkan/vk_types.odin
+++ b/odingame/graphics/vulkan/vk_types.odin
@@ -5,6 +5,10 @@ import sdl "vendor:sdl2"   // For SDL_Window handle
 import "../gfx_interface" // For Gfx_Device, Gfx_Window etc.
 import "core:mem"
 
+// --- Vulkan Specific Constants ---
+MAX_FRAMES_IN_FLIGHT :: 2
+
+
 // --- Vulkan Specific Structs ---
 
 // Vk_Instance_Info stores the Vulkan instance and related data
@@ -52,7 +56,15 @@ Vk_Device_Internal :: struct {
 	present_queue:       vk.Queue,
 	
 	// Allocator that was used to create this device and its sub-resources
-	allocator:           mem.Allocator, 
+	allocator:           mem.Allocator,
+	
+	// Reference to a window, primarily for getting swapchain format for default render pass in pipeline creation.
+	// This is a simplification; a more robust system might involve explicit render target specification.
+	primary_window_for_pipeline: ^Vk_Window_Internal,
+	
+	// Command pool for graphics commands. Could be one per thread or one global.
+	// For simplicity, one global command pool on the device for now.
+	command_pool:        vk.CommandPool, 
 }
 
 // Swapchain_Support_Details stores capabilities needed for swapchain creation
@@ -88,6 +100,36 @@ Vk_Window_Internal :: struct {
 	// render_finished_semaphores: []vk.Semaphore
 	// in_flight_fences:           []vk.Fence
 	// current_frame:              int, // For multi-buffering
+	
+	// Render Pass for this window's swapchain (used by framebuffers and pipelines)
+	render_pass:         vk.RenderPass, 
+	framebuffers:        []vk.Framebuffer, // One per swapchain image view
+
+	// Command Buffers (one per frame in flight, allocated from device's command pool)
+	command_buffers:     [MAX_FRAMES_IN_FLIGHT]vk.CommandBuffer,
+
+	// Synchronization objects
+	image_available_semaphores: [MAX_FRAMES_IN_FLIGHT]vk.Semaphore,
+	render_finished_semaphores: [MAX_FRAMES_IN_FLIGHT]vk.Semaphore,
+	in_flight_fences:           [MAX_FRAMES_IN_FLIGHT]vk.Fence,
+	images_in_flight:           []vk.Fence, // To map swapchain images to fences, size of swapchain_images
+
+	current_frame_index: u32, // Cycles from 0 to MAX_FRAMES_IN_FLIGHT - 1
+
+	// State for the current frame being recorded (set by begin_frame, used by draw commands)
+	// These are effectively "cached" or "active" states for the current recording.
+	// They are not Vulkan objects themselves but rather references or values.
+	active_command_buffer: vk.CommandBuffer, // Command buffer currently being recorded
+	acquired_image_index: u32,            // Swapchain image index acquired by vkAcquireNextImageKHR
+	
+	// Store the layout and render pass of the currently bound pipeline
+	// This is needed for commands like vkCmdBindDescriptorSets (later) or vkCmdBeginRenderPass (if render pass is dynamic per pipeline)
+	// For now, render pass is associated with window, pipeline layout with pipeline.
+	active_pipeline_layout: vk.PipelineLayout, 
+	// active_render_pass: vk.RenderPass, // If render pass can change frequently. For now, window has one.
+	
+	active_vao: gfx_interface.Gfx_Vertex_Array, // Currently bound VAO for the window context
+
 
 	allocator:           mem.Allocator, // Allocator for this struct and its slices
 	recreating_swapchain: bool, // Flag to indicate swapchain needs recreation (e.g. after resize)

--- a/odingame/graphics/vulkan/vk_vao.odin
+++ b/odingame/graphics/vulkan/vk_vao.odin
@@ -1,0 +1,187 @@
+package vulkan
+
+import vk "vendor:vulkan"
+import "core:log"
+import "core:mem"
+import "../gfx_interface" // For Gfx_Device, Gfx_Error, Gfx_Vertex_Array, Vertex_Format, Vertex_Buffer_Layout, Gfx_Buffer
+
+// --- Aliases for Vulkan Structs (for clarity or potential future extension) ---
+Vk_Vertex_Input_Binding_Description :: vk.VertexInputBindingDescription
+Vk_Vertex_Input_Attribute_Description :: vk.VertexInputAttributeDescription
+
+// Vk_Vertex_Array_Internal stores the processed vertex input state descriptions
+// and references to the associated graphics buffers.
+Vk_Vertex_Array_Internal :: struct {
+	// Processed Vulkan descriptions derived from gfx_interface.Vertex_Buffer_Layout
+	binding_descriptions:    []Vk_Vertex_Input_Binding_Description,
+	attribute_descriptions:  []Vk_Vertex_Input_Attribute_Description,
+
+	// References to the Gfx_Buffer handles provided at creation.
+	// The actual VkBuffer handles will be extracted from these when binding.
+	vertex_buffers_gfx:      []gfx_interface.Gfx_Buffer, 
+	vertex_buffer_offsets:   []vk.DeviceSize, // Offsets for vkCmdBindVertexBuffers
+
+	index_buffer_gfx:        gfx_interface.Gfx_Buffer,
+	index_buffer_offset:     vk.DeviceSize,   // Offset for vkCmdBindIndexBuffer
+	index_type:              vk.IndexType,    // e.g., .UINT16 or .UINT32
+
+	allocator_ref:           mem.Allocator, // Allocator used for this struct and its slices
+}
+
+// map_vertex_format_to_vk converts gfx_interface.Vertex_Format to vk.Format.
+map_vertex_format_to_vk :: proc(format: gfx_interface.Vertex_Format) -> (vk_format: vk.Format, found: bool) {
+	#partial switch format {
+	case .Float32_X1: return .R32_SFLOAT, true
+	case .Float32_X2: return .R32G32_SFLOAT, true
+	case .Float32_X3: return .R32G32B32_SFLOAT, true
+	case .Float32_X4: return .R32G32B32A32_SFLOAT, true
+	case .Unorm8_X4:  return .R8G8B8A8_UNORM, true
+	// Add other formats as needed:
+	// case .Sint16_X2: return .R16G16_SINT, true
+	}
+	log.errorf("Unsupported gfx_interface.Vertex_Format: %v", format)
+	return .UNDEFINED, false
+}
+
+// vk_create_vertex_array_internal translates gfx_interface layouts to Vulkan descriptions
+// and stores them along with buffer references.
+vk_create_vertex_array_internal :: proc(
+	gfx_device: gfx_interface.Gfx_Device, // Needed to get allocator
+	vertex_buffer_layouts: []gfx_interface.Vertex_Buffer_Layout,
+	vertex_buffers: []gfx_interface.Gfx_Buffer, // Must match layouts in terms of binding points
+	index_buffer_param: gfx_interface.Gfx_Buffer, // Using _param to avoid conflict if Gfx_Buffer is named 'index_buffer'
+) -> (gfx_interface.Gfx_Vertex_Array, gfx_interface.Gfx_Error) {
+
+	vk_dev_internal, ok_dev := gfx_device.variant.(Vk_Device_Variant)
+	if !ok_dev || vk_dev_internal == nil {
+		log.error("vk_create_vertex_array: Invalid Gfx_Device (not Vulkan or nil variant).")
+		return gfx_interface.Gfx_Vertex_Array{}, .Invalid_Handle
+	}
+	allocator := vk_dev_internal.allocator
+
+	// Allocate the main struct
+	vk_vao_internal := new(Vk_Vertex_Array_Internal, allocator)
+	vk_vao_internal.allocator_ref = allocator
+	
+	// --- Process Vertex Buffer Layouts ---
+	// Use dynamic arrays for building up descriptions, then clone to vk_vao_internal.
+	// These use context.temp_allocator or a temporary arena.
+	temp_bindings    := make([dynamic]Vk_Vertex_Input_Binding_Description, 0, len(vertex_buffer_layouts), context.temp_allocator)
+	defer delete(temp_bindings)
+	temp_attributes  := make([dynamic]Vk_Vertex_Input_Attribute_Description, 0, 8, context.temp_allocator) // Pre-allocate for a few attributes
+	defer delete(temp_attributes)
+
+	// Store Gfx_Buffer handles and their offsets for vkCmdBindVertexBuffers
+	// We need to ensure vertex_buffers maps correctly to vertex_buffer_layouts based on binding index.
+	// The Gfx_Interface suggests vertex_buffers is an array, and layouts refer to these by index or binding point.
+	// For simplicity, assume the i-th Gfx_Buffer in vertex_buffers corresponds to a layout that uses binding 'i'.
+	// A more robust system would use a map or require layouts to specify which Gfx_Buffer index they use.
+	// For now, assume layout.binding is the index into the vertex_buffers array if that's how it's intended.
+	// Or, more commonly, layout.binding is the actual Vulkan binding number.
+	
+	// Let's assume layout.binding refers to the Vulkan binding point.
+	// The vertex_buffers slice corresponds to these binding points if sorted or if user ensures consistency.
+	// For this implementation, we'll iterate layouts and assume the Gfx_Buffer is found via its binding.
+	
+	// Store Gfx_Buffer handles and offsets
+	// We need to determine the offsets for vkCmdBindVertexBuffers. The gfx_interface.Vertex_Buffer_Layout
+	// itself does not provide buffer-level offsets, only attribute offsets *within* a vertex.
+	// The `set_vertex_buffer` call in `Gfx_Device_Interface` takes an offset.
+	// This implies that the VAO might not need to store these offsets if they are provided at bind time.
+	// However, Vulkan's vkCmdBindVertexBuffers takes an array of offsets.
+	// Let's assume the Gfx_Vertex_Array will store these intended offsets.
+	// The `gfx_interface.create_vertex_array` does not take offsets per buffer.
+	// This is a small design gap. For now, assume offsets are 0 for all vertex buffers bound via VAO.
+	// The individual set_vertex_buffer will handle specific offsets if called outside VAO context (which is not typical for Vulkan).
+
+	// Store Gfx_Buffer handles (vertex_buffers)
+	if len(vertex_buffers) > 0 {
+		vk_vao_internal.vertex_buffers_gfx = make([]gfx_interface.Gfx_Buffer, len(vertex_buffers), allocator)
+		vk_vao_internal.vertex_buffer_offsets = make([]vk.DeviceSize, len(vertex_buffers), allocator) // Initialize all to 0
+		for i, vb_gfx in vertex_buffers {
+			vk_vao_internal.vertex_buffers_gfx[i] = vb_gfx
+			// vk_vao_internal.vertex_buffer_offsets[i] = 0; // Default offset 0, already done by make
+		}
+	}
+
+
+	for _, layout_desc in vertex_buffer_layouts {
+		binding_desc := Vk_Vertex_Input_Binding_Description{
+			binding = layout_desc.binding,
+			stride = layout_desc.stride_in_bytes,
+			// TODO: inputRate based on layout_desc.step_rate if added to gfx_interface
+			inputRate = .VERTEX, // Default to per-vertex
+		}
+		append(&temp_bindings, binding_desc)
+
+		for _, attr_desc_gfx in layout_desc.attributes {
+			vk_fmt, ok_fmt := map_vertex_format_to_vk(attr_desc_gfx.format)
+			if !ok_fmt {
+				log.errorf("Failed to map vertex format %v to Vulkan format for VAO creation.", attr_desc_gfx.format)
+				// Cleanup allocated vk_vao_internal
+				free(vk_vao_internal.vertex_buffers_gfx)
+				free(vk_vao_internal.vertex_buffer_offsets)
+				free(vk_vao_internal)
+				return gfx_interface.Gfx_Vertex_Array{}, .Invalid_Handle // Or .Shader_Compilation_Failed if format is for shaders
+			}
+			
+			attribute := Vk_Vertex_Input_Attribute_Description{
+				location = attr_desc_gfx.location,
+				binding = attr_desc_gfx.buffer_binding, // Which binding description this attribute uses
+				format = vk_fmt,
+				offset = attr_desc_gfx.offset_in_bytes,
+			}
+			append(&temp_attributes, attribute)
+		}
+	}
+
+	// Clone from temporary dynamic arrays to the struct's slices
+	if len(temp_bindings) > 0 {
+		vk_vao_internal.binding_descriptions = 추천slice.clone(temp_bindings[:], allocator)
+	}
+	if len(temp_attributes) > 0 {
+		vk_vao_internal.attribute_descriptions = slice.clone(temp_attributes[:], allocator)
+	}
+
+	// --- Store Index Buffer Reference ---
+	vk_vao_internal.index_buffer_gfx = index_buffer_param
+	// The Gfx_Interface for create_vertex_array doesn't take an offset for the index buffer.
+	// Assume offset 0 for now. The `set_index_buffer` interface call *does* take an offset.
+	vk_vao_internal.index_buffer_offset = 0 
+	// Index type: Assume UINT32 for now. A more robust solution would inspect buffer properties
+	// or have it specified in Gfx_Buffer or Gfx_Vertex_Array creation.
+	vk_vao_internal.index_type = .UINT32 
+	// Example: if index_buffer_param has a property for element size:
+	// if get_buffer_element_size(index_buffer_param) == 2 { vk_vao_internal.index_type = .UINT16 }
+
+	log.infof("Vk_Vertex_Array_Internal %p created. Bindings: %d, Attributes: %d. VB count: %d, IB provided: %v",
+		vk_vao_internal,
+		len(vk_vao_internal.binding_descriptions),
+		len(vk_vao_internal.attribute_descriptions),
+		len(vk_vao_internal.vertex_buffers_gfx),
+		vk_vao_internal.index_buffer_gfx.variant != nil,
+	)
+	
+	return gfx_interface.Gfx_Vertex_Array{variant = vk_vao_internal}, .None
+}
+
+// vk_destroy_vertex_array_internal frees memory associated with Vk_Vertex_Array_Internal.
+vk_destroy_vertex_array_internal :: proc(vao_handle: gfx_interface.Gfx_Vertex_Array) {
+	vk_vao_ptr, ok_vao := vao_handle.variant.(^Vk_Vertex_Array_Internal)
+	if !ok_vao || vk_vao_ptr == nil {
+		log.errorf("vk_destroy_vertex_array: Invalid Gfx_Vertex_Array type or nil variant (%v).", vao_handle.variant)
+		return
+	}
+
+	log.infof("Destroying Vk_Vertex_Array_Internal %p.", vk_vao_ptr)
+	
+	// Free the slices within the struct
+	delete(vk_vao_ptr.binding_descriptions)
+	delete(vk_vao_ptr.attribute_descriptions)
+	delete(vk_vao_ptr.vertex_buffers_gfx) // This deletes the slice of Gfx_Buffer handles, not the buffers themselves
+	delete(vk_vao_ptr.vertex_buffer_offsets)
+	// index_buffer_gfx is not a slice
+
+	// Free the struct itself
+	free(vk_vao_ptr, vk_vao_ptr.allocator_ref)
+}

--- a/odingame/graphics/vulkan/vk_window.odin
+++ b/odingame/graphics/vulkan/vk_window.odin
@@ -197,6 +197,26 @@ vk_create_swapchain_internal_logic :: proc(
 	vk_win_internal.swapchain_format = surface_format.format
 	vk_win_internal.swapchain_extent = extent
 
+	// --- Create Render Pass (if not already created for this window) ---
+	// This render pass is owned by the window and used for its framebuffers.
+	// Pipelines must be compatible with this render pass.
+	if vk_win_internal.render_pass == vk.NULL_HANDLE {
+		rp, rp_err := vk_create_render_pass_internal(logical_device, vk_win_internal.swapchain_format)
+		if rp_err != .None {
+			log.errorf("Failed to create render pass for window: %v", rp_err)
+			// Cleanup new swapchain and its images/views if render pass fails
+			// This path is complex; for now, assume render pass creation succeeds if swapchain does.
+			// A more robust cleanup would be needed here.
+			vk.DestroySwapchainKHR(logical_device, vk_win_internal.swapchain, p_vk_allocator)
+			vk_win_internal.swapchain = vk.NULL_HANDLE
+			// Also need to clean up swapchain_images and swapchain_image_views if they were populated
+			return .Device_Creation_Failed 
+		}
+		vk_win_internal.render_pass = rp
+		log.infof("Window render pass created: %p", vk_win_internal.render_pass)
+	}
+
+
 	// --- Get Swapchain Images ---
 	var sc_image_count: u32
 	vk.GetSwapchainImagesKHR(logical_device, vk_win_internal.swapchain, &sc_image_count, nil)
@@ -253,8 +273,95 @@ vk_create_swapchain_internal_logic :: proc(
 		}
 	}
 	log.infof("Created %d image views for swapchain images.", sc_image_count)
+
+	// --- Create Framebuffers ---
+	// Framebuffers depend on image views and the render pass.
+	// Destroy old framebuffers first if this is a recreation.
+	vk_destroy_framebuffers_internal(logical_device, vk_win_internal, p_vk_allocator) // Defined below
+	fb_err := vk_create_framebuffers_internal(logical_device, vk_win_internal, p_vk_allocator)
+	if fb_err != .None {
+		log.error("Failed to create framebuffers for swapchain.")
+		// Extensive cleanup needed here: new image views, new images, new swapchain, potentially render pass if just created.
+		// This indicates a critical failure. For now, returning error.
+		// A robust implementation would unwind all creations from this function.
+		vk_destroy_swapchain_image_views(logical_device, vk_win_internal, p_vk_allocator)
+		delete(vk_win_internal.swapchain_images) // Images are owned by swapchain
+		vk_win_internal.swapchain_images = nil
+		vk.DestroySwapchainKHR(logical_device, vk_win_internal.swapchain, p_vk_allocator)
+		vk_win_internal.swapchain = vk.NULL_HANDLE
+		// Render pass is not destroyed here as it's window-owned, assumed to be valid if we got this far.
+		return .Device_Creation_Failed
+	}
 	
+	// Initialize images_in_flight fence array (size of swapchain images)
+	// This should be done only once when the number of swapchain images is first known,
+	// or if it changes (unlikely without full swapchain recreation).
+	if vk_win_internal.images_in_flight == nil || len(vk_win_internal.images_in_flight) != int(sc_image_count) {
+		delete(vk_win_internal.images_in_flight) // Delete old slice if sizes differ (or first time)
+		vk_win_internal.images_in_flight = make([]vk.Fence, sc_image_count, allocator)
+		// Initialize all to NULL_HANDLE (Odin default for slices of pointers/handles)
+		log.debugf("Initialized images_in_flight fence array with size %d", sc_image_count)
+	}
+
+
 	vk_win_internal.recreating_swapchain = false // Successfully (re)created
+	return .None
+}
+
+
+// vk_destroy_framebuffers_internal cleans up framebuffers.
+vk_destroy_framebuffers_internal :: proc(logical_device: vk.Device, vk_win_internal: ^Vk_Window_Internal, p_vk_allocator: ^vk.AllocationCallbacks) {
+	if vk_win_internal == nil || vk_win_internal.framebuffers == nil {
+		return
+	}
+	log.debugf("Destroying %d framebuffers for swapchain %p", len(vk_win_internal.framebuffers), vk_win_internal.swapchain)
+	for _, fb in vk_win_internal.framebuffers {
+		if fb != vk.NULL_HANDLE {
+			vk.DestroyFramebuffer(logical_device, fb, p_vk_allocator)
+		}
+	}
+	delete(vk_win_internal.framebuffers)
+	vk_win_internal.framebuffers = nil
+}
+
+// vk_create_framebuffers_internal creates framebuffers for the swapchain image views.
+vk_create_framebuffers_internal :: proc(logical_device: vk.Device, vk_win_internal: ^Vk_Window_Internal, p_vk_allocator: ^vk.AllocationCallbacks) -> gfx_interface.Gfx_Error {
+	if vk_win_internal.render_pass == vk.NULL_HANDLE {
+		log.error("Cannot create framebuffers: Window render pass is NULL.")
+		return .Invalid_Handle // Or .Not_Ready
+	}
+	if len(vk_win_internal.swapchain_image_views) == 0 {
+		log.error("Cannot create framebuffers: No swapchain image views available.")
+		return .Not_Ready 
+	}
+
+	num_images := len(vk_win_internal.swapchain_image_views)
+	vk_win_internal.framebuffers = make([]vk.Framebuffer, num_images, vk_win_internal.allocator)
+	
+	for i := 0; i < num_images; i = i + 1 {
+		attachments := [1]vk.ImageView{vk_win_internal.swapchain_image_views[i]} // Array of one image view
+		fb_create_info := vk.FramebufferCreateInfo{
+			sType = .FRAMEBUFFER_CREATE_INFO,
+			renderPass = vk_win_internal.render_pass,
+			attachmentCount = 1,
+			pAttachments = &attachments[0],
+			width = vk_win_internal.swapchain_extent.width,
+			height = vk_win_internal.swapchain_extent.height,
+			layers = 1,
+		}
+		fb_res := vk.CreateFramebuffer(logical_device, &fb_create_info, p_vk_allocator, &vk_win_internal.framebuffers[i])
+		if fb_res != .SUCCESS {
+			log.errorf("vkCreateFramebuffer failed for image view %d. Result: %v", i, fb_res)
+			// Cleanup already created framebuffers for this attempt
+			for j := 0; j < i; j = j + 1 {
+				vk.DestroyFramebuffer(logical_device, vk_win_internal.framebuffers[j], p_vk_allocator)
+			}
+			delete(vk_win_internal.framebuffers)
+			vk_win_internal.framebuffers = nil
+			return .Device_Creation_Failed
+		}
+	}
+	log.infof("Created %d framebuffers successfully.", num_images)
 	return .None
 }
 
@@ -283,6 +390,10 @@ vk_destroy_swapchain_internal :: proc(logical_device: vk.Device, vk_win_internal
 	// especially if this is called outside of full device destruction.
 	// vk.DeviceWaitIdle(logical_device) // Consider if this is needed here or at a higher level
 
+	// Destroy Framebuffers first, as they depend on image views and render pass
+	vk_destroy_framebuffers_internal(logical_device, vk_win_internal, p_vk_allocator)
+
+	// Then destroy Image Views
 	vk_destroy_swapchain_image_views(logical_device, vk_win_internal, p_vk_allocator)
 	
 	// Swapchain images are owned by the swapchain and destroyed with it, so no explicit vkDestroyImage.
@@ -348,20 +459,139 @@ vk_create_window_wrapper :: proc(
 	// Swapchain and related fields (images, views, format, extent) will be set by vk_create_swapchain_internal_logic.
 	// vk_win_internal.swapchain is initially vk.NULL_HANDLE
 
-	// 4. Create Swapchain and Image Views
-	// This populates the rest of vk_win_internal (swapchain, images, views, format, extent)
+	// Set this window as the primary one for pipeline creation on the device.
+	// This is a simplification. A more robust app might have explicit primary window management.
+	vk_dev_internal.primary_window_for_pipeline = vk_win_internal
+	log.infof("Window %p (SDL: %s) set as primary_window_for_pipeline on device %p", 
+		vk_win_internal, title, vk_dev_internal)
+
+	// 4. Create Swapchain, RenderPass, ImageViews, Framebuffers
+	// This populates vk_win_internal with swapchain, images, views, format, extent, render_pass, framebuffers.
 	swap_err := vk_create_swapchain_internal_logic(vk_dev_internal, vk_win_internal, sdl_win)
 	if swap_err != .None {
-		log.errorf("Initial swapchain creation failed for window '%s': %s", title, gfx_interface.gfx_api.get_error_string(swap_err))
-		// Cleanup surface and SDL window
+		log.errorf("Initial swapchain and related resources creation failed for window '%s': %s", title, gfx_interface.gfx_api.get_error_string(swap_err))
+		if vk_win_internal.render_pass != vk.NULL_HANDLE { // If render pass was created by this attempt
+			vk.DestroyRenderPass(vk_dev_internal.logical_device, vk_win_internal.render_pass, nil)
+		}
 		vk.DestroySurfaceKHR(vk_dev_internal.vk_instance.instance, surface_handle, nil)
 		sdl.DestroyWindow(sdl_win)
-		free(vk_win_internal, allocator) // Free the partially created struct
+		free(vk_win_internal, allocator) 
 		return gfx_interface.Gfx_Window{}, swap_err
 	}
+
+	// 5. Create Synchronization Primitives and Command Buffers
+	// Semaphores and Fences
+	p_vk_allocator: ^vk.AllocationCallbacks = nil
+	semaphore_create_info := vk.SemaphoreCreateInfo{ sType = .SEMAPHORE_CREATE_INFO }
+	fence_create_info := vk.FenceCreateInfo{ sType = .FENCE_CREATE_INFO, flags = {.SIGNALED_BIT} } // Create fences in signaled state
+
+	for i := 0; i < MAX_FRAMES_IN_FLIGHT; i = i + 1 {
+		if vk.CreateSemaphore(vk_dev_internal.logical_device, &semaphore_create_info, p_vk_allocator, &vk_win_internal.image_available_semaphores[i]) != .SUCCESS ||
+		   vk.CreateSemaphore(vk_dev_internal.logical_device, &semaphore_create_info, p_vk_allocator, &vk_win_internal.render_finished_semaphores[i]) != .SUCCESS ||
+		   vk.CreateFence(vk_dev_internal.logical_device, &fence_create_info, p_vk_allocator, &vk_win_internal.in_flight_fences[i]) != .SUCCESS {
+			log.error("Failed to create synchronization primitives for a frame.")
+			// Cleanup already created sync objects, swapchain resources, surface, window... this is extensive.
+			// For now, consider this a fatal error for window creation.
+			// A full cleanup path would be needed in production.
+			vk_destroy_window_internal_resources(vk_win_internal) // Helper to destroy all vk_win_internal contents
+			return gfx_interface.Gfx_Window{}, .Initialization_Failed
+		}
+	}
+	log.infof("Created %d sets of frame synchronization primitives.", MAX_FRAMES_IN_FLIGHT)
+
+	// Command Buffers
+	cmd_buf_alloc_info := vk.CommandBufferAllocateInfo{
+		sType = .COMMAND_BUFFER_ALLOCATE_INFO,
+		commandPool = vk_dev_internal.command_pool,
+		level = .PRIMARY,
+		commandBufferCount = MAX_FRAMES_IN_FLIGHT,
+	}
+	cmd_buf_res := vk.AllocateCommandBuffers(vk_dev_internal.logical_device, &cmd_buf_alloc_info, &vk_win_internal.command_buffers[0])
+	if cmd_buf_res != .SUCCESS {
+		log.errorf("Failed to allocate command buffers: %v", cmd_buf_res)
+		vk_destroy_window_internal_resources(vk_win_internal)
+		return gfx_interface.Gfx_Window{}, .Initialization_Failed
+	}
+	log.infof("Allocated %d primary command buffers.", MAX_FRAMES_IN_FLIGHT)
 	
+	vk_win_internal.current_frame_index = 0 // Initialize current frame index
+
 	log.infof("Vulkan Gfx_Window wrapper created successfully for SDL window '%s'.", title)
 	return gfx_interface.Gfx_Window{variant = Vk_Window_Variant(vk_win_internal)}, .None
+}
+
+// vk_destroy_window_internal_resources is a helper to clean up all resources within Vk_Window_Internal
+// This is called on failure during creation or during full destruction.
+vk_destroy_window_internal_resources :: proc(vk_win: ^Vk_Window_Internal) {
+	if vk_win == nil { return }
+	
+	logical_device := vk_win.device_ref.logical_device // Assume device_ref is valid if vk_win is
+	instance       := vk_win.vk_instance.instance   // Assume vk_instance is valid
+	p_vk_allocator: ^vk.AllocationCallbacks = nil
+
+	// Wait for device idle before destroying window resources, especially if called outside full device destruction.
+	// This ensures command buffers, etc., are no longer in use.
+	if logical_device != vk.NULL_HANDLE {
+		vk.DeviceWaitIdle(logical_device)
+	}
+
+	// Destroy swapchain and its dependent resources (framebuffers, image views, images are handled by it)
+	vk_destroy_swapchain_internal(logical_device, vk_win, p_vk_allocator)
+
+	// Destroy render pass owned by the window
+	if vk_win.render_pass != vk.NULL_HANDLE {
+		log.debugf("Destroying window RenderPass: %p", vk_win.render_pass)
+		vk.DestroyRenderPass(logical_device, vk_win.render_pass, p_vk_allocator)
+		vk_win.render_pass = vk.NULL_HANDLE
+	}
+	
+	// Destroy synchronization primitives
+	for i := 0; i < MAX_FRAMES_IN_FLIGHT; i = i + 1 {
+		if vk_win.image_available_semaphores[i] != vk.NULL_HANDLE {
+			vk.DestroySemaphore(logical_device, vk_win.image_available_semaphores[i], p_vk_allocator)
+		}
+		if vk_win.render_finished_semaphores[i] != vk.NULL_HANDLE {
+			vk.DestroySemaphore(logical_device, vk_win.render_finished_semaphores[i], p_vk_allocator)
+		}
+		if vk_win.in_flight_fences[i] != vk.NULL_HANDLE {
+			vk.DestroyFence(logical_device, vk_win.in_flight_fences[i], p_vk_allocator)
+		}
+	}
+	log.debug("Destroyed frame synchronization primitives.")
+
+	// Command buffers are allocated from device's pool; freed when pool is destroyed or explicitly.
+	// If pool is device-global, explicit free here might be good if window is destroyed before device.
+	// For now, assume they are cleaned up with the command pool owned by Vk_Device_Internal.
+	// Or, if allocated specifically for this window and needs specific cleanup:
+	// if vk_win.device_ref != nil && vk_win.device_ref.command_pool != vk.NULL_HANDLE && vk_win.command_buffers[0] != vk.NULL_HANDLE {
+	// 	log.debugf("Freeing %d command buffers.", MAX_FRAMES_IN_FLIGHT)
+	// 	vk.FreeCommandBuffers(logical_device, vk_win.device_ref.command_pool, MAX_FRAMES_IN_FLIGHT, &vk_win.command_buffers[0])
+	// 	// Clear handles, though struct is about to be freed
+	// 	for i := 0; i < MAX_FRAMES_IN_FLIGHT; i=i+1 { vk_win.command_buffers[i] = vk.NULL_HANDLE }
+	// }
+
+
+	// Destroy surface
+	if vk_win.surface != vk.NULL_HANDLE {
+		vk.DestroySurfaceKHR(instance, vk_win.surface, p_vk_allocator)
+		log.info("Vulkan SurfaceKHR destroyed.")
+		vk_win.surface = vk.NULL_HANDLE
+	}
+	
+	// Destroy SDL window
+	if vk_win.sdl_window != nil {
+		sdl.DestroyWindow(vk_win.sdl_window)
+		log.info("SDL Window destroyed.")
+		vk_win.sdl_window = nil
+	}
+	
+	// Free slices owned by Vk_Window_Internal not covered by other destroys
+	delete(vk_win.images_in_flight) // Slice of fences, fences themselves destroyed above or managed by Vulkan
+
+	// Free the Vk_Window_Internal struct itself
+	// This should be done by the caller of this helper, vk_destroy_window_wrapper
+	// free(vk_win, vk_win.allocator) 
+	// log.info("Vk_Window_Internal struct freed.")
 }
 
 
@@ -371,26 +601,7 @@ vk_destroy_window_wrapper :: proc(window: gfx_interface.Gfx_Window) {
 			sdl.GetWindowTitle(vk_win.sdl_window) if vk_win.sdl_window != nil else "N/A", 
 			vk_win.surface)
 		
-		logical_device := vk_win.device_ref.logical_device
-		instance := vk_win.vk_instance.instance
-		p_vk_allocator: ^vk.AllocationCallbacks = nil
-
-		// Destroy swapchain resources (swapchain, image views)
-		vk_destroy_swapchain_internal(logical_device, vk_win, p_vk_allocator)
-
-		// Destroy surface
-		if vk_win.surface != vk.NULL_HANDLE {
-			vk.DestroySurfaceKHR(instance, vk_win.surface, p_vk_allocator)
-			log.info("Vulkan SurfaceKHR destroyed.")
-			vk_win.surface = vk.NULL_HANDLE
-		}
-		
-		// Destroy SDL window
-		if vk_win.sdl_window != nil {
-			sdl.DestroyWindow(vk_win.sdl_window)
-			log.info("SDL Window destroyed.")
-			vk_win.sdl_window = nil
-		}
+		vk_destroy_window_internal_resources(vk_win) // Call the helper
 		
 		// Free the Vk_Window_Internal struct itself
 		free(vk_win, vk_win.allocator)


### PR DESCRIPTION
…e Rendering

This commit introduces the initial, functional Vulkan graphics backend capable of rendering a single colored triangle. It completes Phase 1 of the broader Vulkan implementation plan.

Key features implemented:
- **Device and Window Management**: Robust setup of Vulkan instance, physical/logical devices, SDL window integration, and swapchain.
- **Shader Loading**: Support for loading GLSL shaders from source (`create_shader_from_source`) using `shaderc` for runtime compilation to SPIR-V, and direct loading of SPIR-V bytecode (`create_shader_from_bytecode`). Includes `VkShaderModule` creation.
- **Pipeline Creation**: Implementation of `create_pipeline` to build `VkPipeline` objects. This includes setting up shader stages, basic vertex input (fixed for now, expanded by VAO), input assembly, dynamic viewport/scissor, rasterization, multisampling (disabled), color blending (basic), and render pass creation (tied to window swapchain format).
- **Buffer Management**: `create_buffer`, `destroy_buffer`, `map_buffer`, `unmap_buffer` for managing `VkBuffer` and `VkDeviceMemory`. Buffers are currently host-visible/coherent.
- **Command Buffer Recording & Frame Management**:
    - `begin_frame`, `end_frame` to manage the frame lifecycle.
    - Command pool and command buffer allocation (`MAX_FRAMES_IN_FLIGHT = 2`).
    - Synchronization primitives (semaphores, fences) for frame pacing.
    - Swapchain image acquisition and presentation.
    - Render pass management (begin/end within clear_screen and end_frame).
    - Drawing commands: `clear_screen`, `set_viewport`, `set_scissor`, `set_pipeline`, `draw`.
- **Vertex Array Object (VAO) Equivalent**:
    - `create_vertex_array` translates `Vertex_Buffer_Layout` into Vulkan vertex input binding and attribute descriptions.
    - `bind_vertex_array` makes a VAO active for subsequent pipeline creation and buffer binding.
    - `set_vertex_buffer` and `set_index_buffer` for binding buffers to command buffers.
    - Pipeline creation now uses the active VAO's layout.
- **Example Program**: A new example `examples/simple_vulkan_triangle` demonstrates the implemented features by drawing a colored triangle.

This lays the foundational graphics abstraction layer for Vulkan. Future phases will build upon this to implement more advanced features of the `gfx_interface`.