### PR TITLE
feat: Create initial homepage for Odinga.me

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Odinga.me - Easy Game Development with Odin</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-[#222831] text-[#DFD0B8]">
+  <header class="bg-[#393E46] shadow-md">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="flex h-16 items-center justify-between">
+        <div class="flex items-center">
+          <a href="#" class="text-2xl font-bold text-[#DFD0B8]">Odinga.me</a>
+        </div>
+        <nav class="hidden md:block">
+          <ul class="ml-10 flex items-baseline space-x-4">
+            <li><a href="#features" class="text-[#DFD0B8] hover:text-[#948979] px-3 py-2 rounded-md text-sm font-medium">Features</a></li>
+            <li><a href="#get-started" class="text-[#DFD0B8] hover:text-[#948979] px-3 py-2 rounded-md text-sm font-medium">Get Started</a></li>
+            <li><a href="https://github.com/Hendrin-Mckay/odingame" target="_blank" rel="noopener noreferrer" class="text-[#DFD0B8] hover:text-[#948979] px-3 py-2 rounded-md text-sm font-medium">GitHub</a></li>
+          </ul>
+        </nav>
+        <!-- Mobile menu button -->
+        <div class="-mr-2 flex md:hidden">
+          <button type="button" class="inline-flex items-center justify-center rounded-md bg-gray-800 p-2 text-gray-400 hover:bg-gray-700 hover:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-800" aria-controls="mobile-menu" aria-expanded="false">
+            <span class="sr-only">Open main menu</span>
+            <!-- Heroicon name: outline/bars-3 -->
+            <svg class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+            </svg>
+            <!-- Heroicon name: outline/x-mark -->
+            <svg class="hidden h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    <!-- Mobile menu, show/hide based on menu state -->
+    <div class="md:hidden" id="mobile-menu">
+      <ul class="space-y-1 px-2 pt-2 pb-3 sm:px-3">
+        <li><a href="#features" class="text-[#DFD0B8] hover:text-[#948979] block px-3 py-2 rounded-md text-base font-medium">Features</a></li>
+        <li><a href="#get-started" class="text-[#DFD0B8] hover:text-[#948979] block px-3 py-2 rounded-md text-base font-medium">Get Started</a></li>
+        <li><a href="https://github.com/Hendrin-Mckay/odingame" target="_blank" rel="noopener noreferrer" class="text-[#DFD0B8] hover:text-[#948979] block px-3 py-2 rounded-md text-base font-medium">GitHub</a></li>
+      </ul>
+    </div>
+  </header>
+  <main>
+    <section class="py-16 sm:py-24 lg:py-32 bg-[#222831]">
+      <div class="mx-auto max-w-2xl text-center">
+        <h1 class="text-4xl font-bold tracking-tight text-[#DFD0B8] sm:text-6xl">
+          Create Games with Ease in Odin
+        </h1>
+        <p class="mt-6 text-lg leading-8 text-[#DFD0B8]/80">
+          Build your dream games with Odinga.me, a modern framework for the Odin programming language. Inspired by XNA, FNA, Monogame, and Pygame for a familiar feel with next-gen power.
+        </p>
+        <div class="mt-10 flex items-center justify-center gap-x-6">
+          <a href="#get-started" class="rounded-md bg-[#948979] px-3.5 py-2.5 text-sm font-semibold text-[#222831] shadow-sm hover:bg-[#DFD0B8] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#DFD0B8]">
+            Get Started
+          </a>
+        </div>
+      </div>
+    </section>
+    <section id="features" class="py-12 sm:py-16 bg-[#393E46]">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <h2 class="text-3xl font-bold tracking-tight text-center text-[#DFD0B8] mb-12">Why Odinga.me?</h2>
+        <div class="grid grid-cols-1 gap-x-8 gap-y-10 sm:grid-cols-2 lg:grid-cols-3 lg:gap-x-12">
+          <div class="text-center">
+            <div class="mb-4 text-3xl text-[#948979]">[ICON: Rocket]</div>
+            <h3 class="text-xl font-semibold leading-7 text-[#DFD0B8]">Easy to Learn</h3>
+            <p class="mt-2 text-base leading-7 text-[#DFD0B8]/80">
+              Get your first game running in minutes. Odinga.me is designed with simplicity in mind, making it perfect for beginners and experienced developers alike.
+            </p>
+          </div>
+          <div class="text-center">
+            <div class="mb-4 text-3xl text-[#948979]">[ICON: Puzzle Pieces]</div>
+            <h3 class="text-xl font-semibold leading-7 text-[#DFD0B8]">Familiar Philosophy</h3>
+            <p class="mt-2 text-base leading-7 text-[#DFD0B8]/80">
+              Leveraging concepts from popular frameworks like XNA, FNA, Monogame, and Pygame, you'll feel right at home.
+            </p>
+          </div>
+          <div class="text-center">
+            <div class="mb-4 text-3xl text-[#948979]">[ICON: Odin Logo/Gear]</div>
+            <h3 class="text-xl font-semibold leading-7 text-[#DFD0B8]">Odin Powered</h3>
+            <p class="mt-2 text-base leading-7 text-[#DFD0B8]/80">
+              Built for the Odin Programming Language, offering performance, modern features, and a joy to use.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section class="py-12 sm:py-16 bg-[#222831]">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <h2 class="text-3xl font-bold tracking-tight text-center text-[#DFD0B8] mb-12">Games Made with Odinga.me</h2>
+        <div class="grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-2 lg:gap-x-8">
+          <div class="rounded-lg bg-[#393E46] p-6 shadow-lg">
+            <div class="flex h-48 items-center justify-center rounded bg-[#948979] text-center font-semibold text-[#222831]">
+              [Pixel Platformer]
+            </div>
+            <h3 class="mt-4 text-xl font-semibold text-[#DFD0B8]">Pixel Adventure</h3>
+            <p class="mt-2 text-sm text-[#DFD0B8]/80">
+              A classic 2D platformer with a modern twist, built entirely with Odinga.me.
+            </p>
+          </div>
+          <div class="rounded-lg bg-[#393E46] p-6 shadow-lg">
+            <div class="flex h-48 items-center justify-center rounded bg-[#948979] text-center font-semibold text-[#222831]">
+              [Space Shooter]
+            </div>
+            <h3 class="mt-4 text-xl font-semibold text-[#DFD0B8]">Galaxy Raiders</h3>
+            <p class="mt-2 text-sm text-[#DFD0B8]/80">
+              Blast your way through alien hordes in this top-down space shooter.
+            </p>
+          </div>
+          <div class="rounded-lg bg-[#393E46] p-6 shadow-lg">
+            <div class="flex h-48 items-center justify-center rounded bg-[#948979] text-center font-semibold text-[#222831]">
+              [Puzzle Game]
+            </div>
+            <h3 class="mt-4 text-xl font-semibold text-[#DFD0B8]">Mind Benders</h3>
+            <p class="mt-2 text-sm text-[#DFD0B8]/80">
+              Challenge your mind with intricate puzzles and clever mechanics.
+            </p>
+          </div>
+          <div class="rounded-lg bg-[#393E46] p-6 shadow-lg">
+            <div class="flex h-48 items-center justify-center rounded bg-[#948979] text-center font-semibold text-[#222831]">
+              [RPG Elements]
+            </div>
+            <h3 class="mt-4 text-xl font-semibold text-[#DFD0B8]">Odin's Quest</h3>
+            <p class="mt-2 text-sm text-[#DFD0B8]/80">
+              Embark on an epic journey in this RPG featuring a rich story and turn-based combat.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section id="get-started" class="bg-[#393E46] py-12 text-center sm:py-16">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <h2 class="text-3xl font-bold tracking-tight text-[#DFD0B8] mb-6">
+          Ready to Dive In?
+        </h2>
+        <p class="text-lg leading-8 text-[#DFD0B8]/80 mb-8">
+          Getting started with Odinga.me is simple! Clone the repository from GitHub, explore the examples, and start building your first Odin-powered game today.
+        </p>
+        <a href="https://github.com/Hendrin-Mckay/odingame" target="_blank" rel="noopener noreferrer" class="rounded-md bg-[#DFD0B8] px-4 py-3 text-base font-semibold text-[#222831] shadow-sm hover:bg-[#948979] hover:text-[#DFD0B8] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#948979]">
+          Go to GitHub
+        </a>
+        <p class="mt-8 text-sm text-[#DFD0B8]/70">
+          Odinga.me is proud to be open source, licensed under the LGPL-2.1. We encourage contributions from the community!
+        </p>
+      </div>
+    </section>
+    <!-- Other sections will follow here -->
+  </main>
+  <footer class="bg-[#393E46] text-[#DFD0B8]/70">
+    <div class="mx-auto max-w-7xl px-6 py-8 lg:px-8">
+      <div class="mt-4 flex items-center justify-center space-x-4" aria-label="Footer navigation">
+        <a href="#features" class="text-sm font-semibold hover:text-[#DFD0B8]">Features</a>
+        <a href="https://github.com/Hendrin-Mckay/odingame" target="_blank" rel="noopener noreferrer" class="text-sm font-semibold hover:text-[#DFD0B8]">GitHub</a>
+      </div>
+      <p class="mt-8 text-center text-xs leading-5">
+        &copy; 2024 Odinga.me. All rights reserved. Licensed under LGPL-2.1.
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,20 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  body {
+    background-color: #222831; /* dark-grey */
+    color: #DFD0B8; /* light-beige */
+  }
+  /* Define custom color classes if needed, though direct use of hex in Tailwind is often preferred for simplicity unless these specific names are crucial for many components */
+  .bg-dark-grey { background-color: #222831; }
+  .bg-medium-grey { background-color: #393E46; }
+  .text-desaturated-brown { color: #948979; }
+  .border-desaturated-brown { border-color: #948979; }
+  .text-light-beige { color: #DFD0B8; }
+  .bg-light-beige { background-color: #DFD0B8; } /* Added for flexibility */
+  .hover\:text-desaturated-brown:hover { color: #948979; } /* For link hovers etc. */
+}
+
+/* Placeholder for any additional custom CSS not achievable with Tailwind */


### PR DESCRIPTION
This commit introduces the first version of the Odinga.me homepage, located at `docs/index.html`.

Key features implemented:
- Responsive design using Tailwind CSS.
- Adherence to the specified color palette (#222831, #393E46, #948979, #DFD0B8).
- Header with navigation (Features, Get Started, GitHub).
- Hero section emphasizing ease of use with Odin and similarities to XNA/FNA/Monogame/Pygame.
- "Why Odinga.me?" section detailing key benefits.
- "Games Made with Odinga.me" section with placeholder examples.
- "Get Started" call to action with a link to the GitHub repository and license information (LGPL-2.1).
- Footer with copyright and navigation.

The page structure includes `index.html` and a `style.css` for base Tailwind configuration. Section order was refined for better user experience, and non-functional links were removed. The hero section background was explicitly set to ensure dark theme consistency based on feedback.